### PR TITLE
Add origami __about endpoints (#14 and #15)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,8 @@
 var polyfillio = require('./index'),
 	express = require('express'),
-	app = express();
+	app = express(),
+	packagejson = require('./package.json'),
+	origamijson = require('./origami.json');
 
 'use strict';
 
@@ -8,8 +10,34 @@ var aliasResolver = AliasResolver.createDefault(polyfillio.aliases),
 	port = 3000;
 
 
+/** Return information about the web service
+ *  See Origami spec:
+ *  	http://origami.ft.com/docs/syntax/web-service-index/
+ */
 app.get(/^\/__about$/, function(req, res) {
-	res.send("__about");
+	var info = {
+		"name": "polyfill-service",
+		"versions": [
+			"/v1/"
+		]
+	};
+	res.set("Content-Type", "application/json");
+	res.send(JSON.stringify(info));
+});
+
+
+app.get(/^\/v1\/__about$/, function(req, res) {
+	var info = {
+		"name": "polyfill-service",
+		"apiVersion": 1,
+		"appVersion": packagejson.version,
+		"dateCreated": '2014-07-14T10:28:45Z',
+		"support": origamijson.support,
+		"supportStatus": "active"
+	};
+
+	res.set("Content-Type", "application/json");
+	res.send(JSON.stringify(info));
 });
 
 app.get(/^\/v1\/polyfill(\.\w+)(\.\w+)?/, function(req, res) {


### PR DESCRIPTION
Depends on Origami JSON in #21.  Not sure if Github will change this to master once `origamijson` has been merged...

This is relatively simple, it adds two new endpoints containing the relevant data based on the spec.  It depends on the configuration in package.json and origami.json.
