### PR TITLE
Add ACAO header for CORS

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ app.get(/^\/v1\/polyfill(\.\w+)(\.\w+)?/, function(req, res) {
 	}
 
 	res.set('Vary', 'User-Agent');
+	res.set('Access-Control-Allow-Origin', '*');
 	res.send(polyfill);
 });
 


### PR DESCRIPTION
Add ACAO (Access-Control-Allow-Origin) header for CORS (Cross Origin Resource Sharing).

Closes issue #13.
