### PR TITLE
Add __gtg endpoint

### DIFF
--- a/service/index.js
+++ b/service/index.js
@@ -41,6 +41,12 @@ app.get(/^\/v1\/__about$/, function(req, res) {
 	res.send(JSON.stringify(info));
 });
 
+app.get(/^\/__gtg$/, function(req, res) {
+	res.set("Content-Type", "text/plain");
+	res.set("Cache-Control", "no-store");
+	res.send("OK");
+});
+
 app.get(/^\/v1\/polyfill(\.\w+)(\.\w+)?/, function(req, res) {
 
 	var firstParameter = req.params[0].toLowerCase(),


### PR DESCRIPTION
Adds the `/__gtg` endpoint according to the spec.

A comment has been added to the spec however as it does not define the behaviour in the event the connection is refused or the endpoint becomes unavailable.  This can't be handled according to the spec solely using HTTP response codes as the only dependency for the application is a single Node JS process. If the process is down `/__gtg` can not be served - which is the reason this endpoint simply return OK with a 200 response code.

Closes #31.
