### PR TITLE
Include all polyfills if there were no polyfills asked for.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,18 @@ function getPolyfillString(options) {
 		ua.patch = '0';
 	}
 
-	var expandedPolyfillList = aliasResolver.resolve(options.polyfills);
+	var desired = options.polyfills
+	if (desired.length === 0) {
+		desired = Object.keys(sources).map(function(name) {
+			return {
+				flags: ['maybe'],
+				name: name,
+				aliasOf: name
+			}
+		})
+	}
+
+	var expandedPolyfillList = aliasResolver.resolve(desired);
 
 	expandedPolyfillList.forEach(function(polyfill) {
 		var polyfillSource = sources[polyfill.name];


### PR DESCRIPTION
The default behaviour of polyfill.io is that it will try to fill all polyfills by default. I'm not sure if it's intentional that you've disabled this. If it is, perhaps you'd consider this as an alternative, if you haven't requested any polyfills then treat it as requesting all.
