### PR TITLE
Properly handle SVGElement className properties in spliceClassList.

### DIFF
--- a/polyfills/Window.prototype.DOMTokenList/polyfill.js
+++ b/polyfills/Window.prototype.DOMTokenList/polyfill.js
@@ -3,10 +3,20 @@
 	function spliceClassList(classList) {
 		Array.prototype.splice.call(classList, 0, classList.length);
 
-		if (classList.element.className.trim()) {
-			Array.prototype.push.apply(classList, classList.element.className.trim().split(/\s+/));
+		var className = classList.element.className
+		if (typeof className === 'string') {
+			className = className.trim()
+			if (className.trim()) {
+				Array.prototype.push.apply(classList, className.trim().split(/\s+/));
+			}
 		}
-
+		// AN SVG element's className property  an object with baseVal and
+		// animVal string properties containing the className
+		else if(typeof className === 'object') {
+			if (className.baseVal && className.baseVal.trim()) {
+				Array.prototype.push.apply(classList, className.baseVal.trim().split(/\s+/));
+			}
+  		}
 		return classList;
 	}
 

--- a/polyfills/Window.prototype.DOMTokenList/polyfill.js
+++ b/polyfills/Window.prototype.DOMTokenList/polyfill.js
@@ -3,20 +3,11 @@
 	function spliceClassList(classList) {
 		Array.prototype.splice.call(classList, 0, classList.length);
 
-		var className = classList.element.className
-		if (typeof className === 'string') {
-			className = className.trim()
-			if (className.trim()) {
-				Array.prototype.push.apply(classList, className.trim().split(/\s+/));
-			}
+		// We use getAttribute to normalise element.className implementations
+		var className = classList.getAttribute('class')
+		if (className && className.trim()) {
+			Array.prototype.push.apply(classList, className.trim().split(/\s+/));
 		}
-		// AN SVG element's className property  an object with baseVal and
-		// animVal string properties containing the className
-		else if(typeof className === 'object') {
-			if (className.baseVal && className.baseVal.trim()) {
-				Array.prototype.push.apply(classList, className.baseVal.trim().split(/\s+/));
-			}
-  		}
 		return classList;
 	}
 

--- a/polyfills/Window.prototype.DOMTokenList/polyfill.js
+++ b/polyfills/Window.prototype.DOMTokenList/polyfill.js
@@ -4,9 +4,9 @@
 		Array.prototype.splice.call(classList, 0, classList.length);
 
 		// We use getAttribute to normalise element.className implementations
-		var className = classList.getAttribute('class')
-		if (className && className.trim()) {
-			Array.prototype.push.apply(classList, className.trim().split(/\s+/));
+		var className = (classList.getAttribute('class') || '').replace(/^\s+|\s+$/g, '');
+		if (className) {
+			Array.prototype.push.apply(classList, className.split(/\s+/));
 		}
 		return classList;
 	}


### PR DESCRIPTION
SVG elements have a special className property, it's not a string like HTMLElements, rather an object. I don't understand the intricacies of the differences between animVal and baseVal, but in our experience you can simply work with baseVal.
