### PR TITLE
Alias refactor

### DIFF
--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -13,30 +13,21 @@ module.exports = (function() {
 	var aliasResolverFunctions = [];
 
 	/**
-	 * Run an alias resolution function over each element in an array of polyfill objects.
+	 * Run an alias resolver function over each element in an array of polyfill identifier objects.
 	 *
-	 * Each polyfill object's name may be an alias rather than a canonical name. The
-	 * resolving function may try to expand these polyfill names to another
-	 * name. If it does not know how to expand the name, it is ignored and returned without
-	 * change in the new, potentially expanded, array of polyfill objects.
+	 * @param {array}    aliases       A list of polyfill identifiers to expand.
+	 * @param {Function} aliasResolver The alias resolver function to use in
+	 *                                 the resolution process.
 	 *
-	 * @param {array}    aliases       A list of aliased polyfills to expand.
-	 * @param {Function} aliasResolver A function to apply to each polyfill
-	 *                                 object in the list of aliases.  The
-	 *                                 function takes a polyfill as an object,
-	 *                                 and returns an array of polyfill objects
-	 *                                 with an additional 'aliasOf' field to
-	 *                                 indicate the original alias that included
-	 *                                 the polyfill.
-	 *
-	 * @return {array} An expanded list of aliases
+	 * @return {array} An expanded list of polyfill identifiers
 	 */
-	function applyResolverToAliases(aliases, aliasResolver) {
+	function applyResolverToAliases(aliases, aliasResolverFunction) {
 
 		var expandedPolyfills = flatMap(aliases, function(polyfillIdentifier) {
-			// Map the resolver over the aliases and flatten
-			var polyfillIdentifierNames = aliasResolver(polyfillIdentifier.name);
+			var polyfillIdentifierNames = aliasResolverFunction(polyfillIdentifier.name);
 
+			// For each polyfill identifier name, apply the aliases and flags
+			// and return an array of Polyfill Identifier Objects
 			return polyfillIdentifierNames.map(function(name) {
 				return {
 					name: name,
@@ -58,7 +49,8 @@ module.exports = (function() {
 			}
 		});
 
-		// Get the object's values (Kind of like an Object.values function)
+		// Get the object's values (kind of like an imaginary Object.values function) as
+		// an array
 		var arrayOfPolyfills = Object.keys(polyfillSet).map(function(key) { return polyfillSet[key]; });
 
 		return arrayOfPolyfills;
@@ -69,8 +61,12 @@ module.exports = (function() {
 		 * Resolve an array of polyfill identifiers by iteratively invoking the
 		 * resolver functions on each element.
 		 *
-		 * @param {array} polyfillAliases The f aliases to resolve
-		 * @returns {array} An expanded list of resolved aliases.
+		 * @param {array} polyfillIdentifiers The polyfill identifier objects
+		 *                                    to resolve. A polyfill identifier is
+		 *                                    an object with a 'name' property as a string
+		 *                                    and a 'flags' property as an array
+		 *
+		 * @returns {array} An resolved list of resolved polyfill identifiers.
 		 */
 		resolvePolyfills: function(polyfillIdentifiers) {
 			var currentPolyfillIdentifiers = polyfillIdentifiers;
@@ -81,8 +77,15 @@ module.exports = (function() {
 
 			return currentPolyfillIdentifiers;
 		},
-		addResolver: function(func) {
-			aliasResolvers.push(func);
+		/** Add a resolution function to the end of the alias resolution
+		 * logic.
+		 *
+		 * @param {Function} A function that takes a single string argument
+		 *                   and returns an array of string elements
+		 *                   representing the expanded identifiers/aliases.
+		 */
+		addResolver: function(resolverFunction) {
+			aliasResolvers.push(resolverFunction);
 			return this;
 		},
 		clearResolvers: function() {

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -4,39 +4,13 @@
  */
 module.exports = (function() {
 
-	// Each function takes a Polyfill identifier and, if it is not a canonical
-	// identifier, tries to unalias the name to a canonical name or another
-	// alias closer to a canonical name.
-	//
-	// Each function is called with the result of the previous function,
-
-	// A list of functions that transform aliases to canonical polyfill names.
-	// Each step should work towards resolving an alias to a canonical
-	// polyfill name and each step should preserve the alias that was used to
-	// include the canonical polyfill by adding an aliasOf property on each
-	// object.  If a name can not be resolved it should be returned to allow
-	// subsequent resolving functions to handle and to allow any canonical
-	// names that have already been resolved to pass through each function.
-	var aliasResolvers = [];
-
-	/**
-	 * Resolve an alias using the resolver function list.  Each is called in turn until
-	 * a list of expandedAliases remain.  The current list of expanded aliases
-	 * is passed to the next function in the list to achieve a cheap linear expansion of
-	 * names.
+	/** An array of functions that map a string identifier (e.g. an alias) to an array of
+	 * potentially alternate string identifiers (e.g. expanded names the alias refers to)
 	 *
-	 * @param {array} polyfillAliases The list of aliases to resolve
-	 * @returns {array} An expanded list of resolved aliases.
+	 * The key point is that each is invoked in sequence with the result of
+	 * the previous function.
 	 */
-	function resolve(polyfillAliases) {
-		var expandedAliases = polyfillAliases;
-
-		aliasResolvers.forEach(function(resolver) {
-			expandedAliases = applyResolverToAliases(expandedAliases, resolver);
-		});
-
-		return expandedAliases;
-	};
+	var aliasResolverFunctions = [];
 
 	/**
 	 * Run an alias resolution function over each element in an array of polyfill objects.
@@ -84,14 +58,29 @@ module.exports = (function() {
 			}
 		});
 
-		// Get the objects values (Kind of like an Object.values function)
+		// Get the object's values (Kind of like an Object.values function)
 		var arrayOfPolyfills = Object.keys(polyfillSet).map(function(key) { return polyfillSet[key]; });
 
 		return arrayOfPolyfills;
 	}
 
 	return {
-		resolvePolyfills: resolve,
+		/**
+		 * Resolve an array of polyfill identifiers by iteratively invoking the
+		 * resolver functions on each element.
+		 *
+		 * @param {array} polyfillAliases The f aliases to resolve
+		 * @returns {array} An expanded list of resolved aliases.
+		 */
+		resolvePolyfills: function(polyfillIdentifiers) {
+			var currentPolyfillIdentifiers = polyfillIdentifiers;
+
+			aliasResolverFunctions.forEach(function(resolverFunction) {
+				currentPolyfillIdentifiers = applyResolverToAliases(currentPolyfillIdentifiers, resolverFunction);
+			});
+
+			return currentPolyfillIdentifiers;
+		},
 		addResolver: function(func) {
 			aliasResolvers.push(func);
 			return this;
@@ -102,13 +91,6 @@ module.exports = (function() {
 	}
 }());
 
-/*
-	if (aliases) {
-	}
-
-	return [polyfill];
-
-	8?§
 /**
  * Apply a function to each element in the array and concatenate the result
  * of the function into a new array.

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -1,6 +1,13 @@
 /**
  * The AliasResolver provides the logic used for expanding and resolving
- * aliases using more than one mechanism (if required).
+ * polyfill identifiers using more than one mechanism (if required).
+ *
+ * A polyfill identifier is an object with at least a 'name' and 'flags'
+ * property, where the 'name' is the string identifying a polyfill and
+ * 'flags' is an array containing any flags that should be applied with
+ * the polyfill (and subsequently to any aliased polyfills).
+ *
+ *  e.g: { name: "modernizr:es5", flags: ["always"] }
  */
 module.exports = (function() {
 
@@ -10,21 +17,23 @@ module.exports = (function() {
 	 * The key point is that each is invoked in sequence with the result of
 	 * the previous function as an argument.
 	 */
-	var aliasResolverFunctions = [];
+	var polyfillNameResolverFunctions = [];
 
 	/**
-	 * Run an alias resolver function over each element in an array of polyfill identifier objects.
+	 * Run a name resolver function over each polyfill identifier in an array,
+	 * remove duplicates after the resolution and keep track of aliases and
+	 * flags.
 	 *
-	 * @param {array}    aliases       A list of polyfill identifiers to expand.
-	 * @param {Function} aliasResolver The alias resolver function to use in
-	 *                                 the resolution process.
+	 * @param {array}    polyfillIdentifiers          A list of polyfill identifiers to expand.
+	 * @param {Function} polyfillNameResolverFunction The identifier name resolver function to use in
+	 *                                                the resolution process.
 	 *
 	 * @return {array} An expanded list of polyfill identifiers
 	 */
-	function applyResolverToAliases(aliases, aliasResolverFunction) {
+	function applyResolverToIdentifiers(polyfillIdentifiers, polyfillNameResolverFunction) {
 
-		var expandedPolyfills = flatMap(aliases, function(polyfillIdentifier) {
-			var polyfillIdentifierNames = aliasResolverFunction(polyfillIdentifier.name);
+		var expandedPolyfills = flatMap(polyfillIdentifiers, function(polyfillIdentifier) {
+			var polyfillIdentifierNames = polyfillNameResolverFunction(polyfillIdentifier.name);
 
 			// For each polyfill identifier name, apply the aliases and flags
 			// and return an array of Polyfill Identifier Objects
@@ -71,8 +80,8 @@ module.exports = (function() {
 		resolvePolyfills: function(polyfillIdentifiers) {
 			var currentPolyfillIdentifiers = polyfillIdentifiers;
 
-			aliasResolverFunctions.forEach(function(resolverFunction) {
-				currentPolyfillIdentifiers = applyResolverToAliases(currentPolyfillIdentifiers, resolverFunction);
+			polyfillNameResolverFunctions.forEach(function(resolverFunction) {
+				currentPolyfillIdentifiers = applyResolverToIdentifiers(currentPolyfillIdentifiers, resolverFunction);
 			});
 
 			return currentPolyfillIdentifiers;
@@ -85,11 +94,11 @@ module.exports = (function() {
 		 *                   representing the expanded identifiers/aliases.
 		 */
 		addResolver: function(resolverFunction) {
-			aliasResolverFunctions.push(resolverFunction);
+			polyfillNameResolverFunctions.push(resolverFunction);
 			return this;
 		},
 		clearResolvers: function() {
-			aliasResolverFunctions = [];
+			polyfillNameResolverFunctions = [];
 		}
 	}
 }());

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -95,6 +95,9 @@ module.exports = (function() {
 		addResolver: function(func) {
 			aliasResolvers.push(func);
 			return this;
+		},
+		clearResolvers: function() {
+			aliasResolvers = [];
 		}
 	}
 }());

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -102,9 +102,16 @@ module.exports = (function() {
 
 
 /**
- * FP Helper:
- * flatMap the terms in the array using lambda.
+ * Apply a function to each element in the array and concatenate the result
+ * of the function into a new array.
+ *
+ * @example The difference between map and flatMap
+ * > [0, 1, 2].map(function(val) {return [val + 1, val + 2]; });
+ * [ [ 1, 2 ], [ 2, 3 ], [ 3, 4 ] ]
+ *
+ * > flatMap([0, 1, 2], function(val) { return [val + 1, val + 2]; });
+ * [ 1, 2, 2, 3, 3, 4 ]
  */
-function flatMap(array, lambda) {
-	return Array.prototype.concat.apply([], array.map(lambda));
+function flatMap(array, func) {
+	return Array.prototype.concat.apply([], array.map(func));
 };

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -11,43 +11,15 @@
  * @param {array} resolvers A list of functions that map any object or string
  *                          to an array of objects or strings.
  */
-function AliasResolver(resolvers) {
-	this.aliasResolvers = resolvers || [
-		function identity(name) {
-			return [name];
-		}
-	];
-}
+module.exports = (function AliasResolver() {
+	var polyfillAliases = {};
 
-/**
- * Resolve an alias usin the resolver functions.  Each is called in turn until
- * a list of expandedAliases remain.
- *
- * @param {array} polyfillAliases The list of aliases to resolve
- * @returns {array} An expanded list of resolved aliases.
- */
-AliasResolver.prototype.resolve = function(polyfillAliases) {
-	var expandedAliases = polyfillAliases;
-
-	this.aliasResolvers.forEach(function(aliasResolver) {
-		expandedAliases = processListOfAliases(expandedAliases, aliasResolver);
-	});
-
-	return expandedAliases;
-};
-
-/**
- * Create the default AliasResolver: This contains a function which uses the
- * polyfills info (which contains the config info for each polyfill) and
- * expands the aliases.
- *
- * @param {Object} polyfills Object containing information about the loaded
- *                           polyfills
- * @return {AliasResolver}
- */
-AliasResolver.createDefault = function(polyfillAliases) {
-	return new AliasResolver([
-		function expandAliasesFromConfig(polyfill) {
+	// A list of functions that resolve names of polyfills
+	// preserving the original polyfill name relationship, this uses the
+	// dictionary of aliases that the module was initialised with using the
+	// initialise function.
+	var aliasResolvers = [
+		function expandAliasFromConfig(polyfill) {
 
 			var aliases = polyfillAliases[polyfill.name];
 
@@ -56,16 +28,87 @@ AliasResolver.createDefault = function(polyfillAliases) {
 					return {
 						name: alias,
 						flags: polyfill.flags,
-						aliasOf: polyfill.aliasOf
+						aliasOf: [polyfill.aliasOf || polyfill.name]
 					};
 				});
 			}
 
 			return [polyfill];
 		}
-	]);
+	];
 
-};
+
+	/**
+	 * Resolve an alias using the resolver function list.  Each is called in turn until
+	 * a list of expandedAliases remain.  The current list of expanded aliases
+	 * is passed to the next function in the list to achieve a cheap linear expansion of
+	 * names.
+	 *
+	 * @param {array} polyfillAliases The list of aliases to resolve
+	 * @returns {array} An expanded list of resolved aliases.
+	 */
+	function resolve(polyfillAliases) {
+		var expandedAliases = polyfillAliases;
+
+		aliasResolvers.forEach(function(resolver) {
+			expandedAliases = applyResolverToAliases(expandedAliases, resolver);
+		});
+
+		return expandedAliases;
+	};
+
+	/**
+	 * Run an alias resolver over each member in a list of aliases.  This should
+	 * result in an array of new names that potentially contain the expanded
+	 * aliases depending on the aliasResolver function.
+	 *
+	 * @param {array}    aliases       A list of aliased polyfills to expand.
+	 * @param {Function} aliasResolver A function to apply to each member in the
+	 *                                 list of aliases.  The function takes a
+	 *                                 polyfill as an object, and returns an array
+	 *                                 of objects with metadata.
+	 * @return {array} An expanded list of aliases
+	 */
+	function applyResolverToAliases(aliases, aliasResolver) {
+
+		var expandedPolyfills = flatMap(aliases, function(name) {
+			// Map the resolver over the aliases and flatten
+			return aliasResolver(name);
+		});
+
+		// Remove duplicates: When removing duplicates, if one is found ->
+		// concat the flags and the aliasOf fields.
+		var polyfillSet = {};
+		expandedPolyfills.forEach(function(polyfill) {
+			if (!polyfillSet[polyfill.name]) {
+				polyfillSet[polyfill.name] = polyfill;
+			} else {
+				polyfillSet[polyfill.name].aliasOf = polyfillSet[polyfill.name].aliasOf.concat(polyfill.aliasOf);
+				polyfillSet[polyfill.name].flags   = polyfillSet[polyfill.name].flags.concat(polyfill.flags);
+			}
+		});
+
+		// Flatten the 'Set' we've created using the Object into an array
+		var arrayOfPolyfills = [];
+		for (var polyfillName in polyfillSet) {
+			if (polyfillSet.hasOwnProperty(polyfillName)) {
+				arrayOfPolyfills.push(polyfillSet[polyfillName]);
+			}
+		}
+
+		return arrayOfPolyfills;
+	}
+
+	function initialise(presetAliases) {
+		polyfillAliases = presetAliases;
+	}
+
+	return {
+		initialise: initialise,
+		resolvePolyfills: resolve
+	}
+}());
+
 
 /**
  * FP Helper:
@@ -74,24 +117,3 @@ AliasResolver.createDefault = function(polyfillAliases) {
 function flatMap(array, lambda) {
 	return Array.prototype.concat.apply([], array.map(lambda));
 };
-
-/**
- * Run an alias resolver over each member in a list of aliases.  This should
- * result in an array of new names that potentially contain the expanded
- * aliases depending on the aliasResolver function.
- *
- * @param {array}    aliases       A list of aliases to expand.
- * @param {Function} aliasResolver A function to apply to each member in the
- *                                 list of aliases.
- * @return {array} An expanded list of aliases
- */
-function processListOfAliases(aliases, aliasResolver) {
-	return flatMap(aliases, function(name) {
-		return aliasResolver(name);
-	}).filter(function(name, position, self) {
-		return self.indexOf(name) == position;
-	});
-}
-
-
-module.exports = AliasResolver;

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -8,7 +8,7 @@ module.exports = (function() {
 	 * potentially alternate string identifiers (e.g. expanded names the alias refers to)
 	 *
 	 * The key point is that each is invoked in sequence with the result of
-	 * the previous function.
+	 * the previous function as an argument.
 	 */
 	var aliasResolverFunctions = [];
 

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -85,11 +85,11 @@ module.exports = (function() {
 		 *                   representing the expanded identifiers/aliases.
 		 */
 		addResolver: function(resolverFunction) {
-			aliasResolvers.push(resolverFunction);
+			aliasResolverFunctions.push(resolverFunction);
 			return this;
 		},
 		clearResolvers: function() {
-			aliasResolvers = [];
+			aliasResolverFunctions = [];
 		}
 	}
 }());

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -2,16 +2,7 @@
  * The AliasResolver provides the logic used for expanding and resolving
  * aliases using more than one mechanism (if required).
  */
-
-/**
- * Construct a new AliasResolver accepting a list of functions that can be
- * used to expand an alias.
- *
- * @constructor
- * @param {array} resolvers A list of functions that map any object or string
- *                          to an array of objects or strings.
- */
-module.exports = (function AliasResolver() {
+module.exports = (function() {
 	var polyfillConfigAliases = {};
 
 	// A list of functions that resolve names of polyfills

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -12,7 +12,7 @@
  *                          to an array of objects or strings.
  */
 module.exports = (function AliasResolver() {
-	var polyfillAliases = {};
+	var polyfillConfigAliases = {};
 
 	// A list of functions that resolve names of polyfills
 	// preserving the original polyfill name relationship, this uses the
@@ -21,7 +21,7 @@ module.exports = (function AliasResolver() {
 	var aliasResolvers = [
 		function expandAliasFromConfig(polyfill) {
 
-			var aliases = polyfillAliases[polyfill.name];
+			var aliases = polyfillConfigAliases[polyfill.name];
 
 			if (aliases) {
 				return aliases.map(function(alias) {
@@ -99,12 +99,12 @@ module.exports = (function AliasResolver() {
 		return arrayOfPolyfills;
 	}
 
-	function initialise(presetAliases) {
-		polyfillAliases = presetAliases;
+	function setUpAliasesFromConfig(presetAliases) {
+		polyfillConfigAliases = presetAliases;
 	}
 
 	return {
-		initialise: initialise,
+		initialiseAliasesFromConfig: setUpAliasesFromConfig,
 		resolvePolyfills: resolve
 	}
 }());

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -19,7 +19,7 @@ module.exports = (function() {
 					return {
 						name: alias,
 						flags: polyfill.flags,
-						aliasOf: [polyfill.aliasOf || polyfill.name]
+						aliasOf: polyfill.aliasOf || [polyfill.name]
 					};
 				});
 			}

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -3,31 +3,21 @@
  * aliases using more than one mechanism (if required).
  */
 module.exports = (function() {
-	var polyfillConfigAliases = {};
 
-	// A list of functions that resolve names of polyfills
-	// preserving the original polyfill name relationship, this uses the
-	// dictionary of aliases that the module was initialised with using the
-	// initialise function.
-	var aliasResolvers = [
-		function expandAliasFromConfig(polyfill) {
+	// Each function takes a Polyfill identifier and, if it is not a canonical
+	// identifier, tries to unalias the name to a canonical name or another
+	// alias closer to a canonical name.
+	//
+	// Each function is called with the result of the previous function,
 
-			var aliases = polyfillConfigAliases[polyfill.name];
-
-			if (aliases) {
-				return aliases.map(function(alias) {
-					return {
-						name: alias,
-						flags: polyfill.flags,
-						aliasOf: polyfill.aliasOf || [polyfill.name]
-					};
-				});
-			}
-
-			return [polyfill];
-		}
-	];
-
+	// A list of functions that transform aliases to canonical polyfill names.
+	// Each step should work towards resolving an alias to a canonical
+	// polyfill name and each step should preserve the alias that was used to
+	// include the canonical polyfill by adding an aliasOf property on each
+	// object.  If a name can not be resolved it should be returned to allow
+	// subsequent resolving functions to handle and to allow any canonical
+	// names that have already been resolved to pass through each function.
+	var aliasResolvers = [];
 
 	/**
 	 * Resolve an alias using the resolver function list.  Each is called in turn until
@@ -49,22 +39,37 @@ module.exports = (function() {
 	};
 
 	/**
-	 * Run an alias resolver over each member in a list of aliases.  This should
-	 * result in an array of new names that potentially contain the expanded
-	 * aliases depending on the aliasResolver function.
+	 * Run an alias resolution function over each element in an array of polyfill objects.
+	 *
+	 * Each polyfill object's name may be an alias rather than a canonical name. The
+	 * resolving function may try to expand these polyfill names to another
+	 * name. If it does not know how to expand the name, it is ignored and returned without
+	 * change in the new, potentially expanded, array of polyfill objects.
 	 *
 	 * @param {array}    aliases       A list of aliased polyfills to expand.
-	 * @param {Function} aliasResolver A function to apply to each member in the
-	 *                                 list of aliases.  The function takes a
-	 *                                 polyfill as an object, and returns an array
-	 *                                 of objects with metadata.
+	 * @param {Function} aliasResolver A function to apply to each polyfill
+	 *                                 object in the list of aliases.  The
+	 *                                 function takes a polyfill as an object,
+	 *                                 and returns an array of polyfill objects
+	 *                                 with an additional 'aliasOf' field to
+	 *                                 indicate the original alias that included
+	 *                                 the polyfill.
+	 *
 	 * @return {array} An expanded list of aliases
 	 */
 	function applyResolverToAliases(aliases, aliasResolver) {
 
-		var expandedPolyfills = flatMap(aliases, function(name) {
+		var expandedPolyfills = flatMap(aliases, function(polyfillIdentifier) {
 			// Map the resolver over the aliases and flatten
-			return aliasResolver(name);
+			var polyfillIdentifierNames = aliasResolver(polyfillIdentifier.name);
+
+			return polyfillIdentifierNames.map(function(name) {
+				return {
+					name: name,
+					flags: polyfillIdentifier.flags,
+					aliasOf: polyfillIdentifier.aliasOf || [polyfillIdentifier.name]
+				};
+			});
 		});
 
 		// Remove duplicates: When removing duplicates, if one is found ->
@@ -79,28 +84,28 @@ module.exports = (function() {
 			}
 		});
 
-		// Flatten the 'Set' we've created using the Object into an array
-		var arrayOfPolyfills = [];
-		for (var polyfillName in polyfillSet) {
-			if (polyfillSet.hasOwnProperty(polyfillName)) {
-				arrayOfPolyfills.push(polyfillSet[polyfillName]);
-			}
-		}
+		// Get the objects values (Kind of like an Object.values function)
+		var arrayOfPolyfills = Object.keys(polyfillSet).map(function(key) { return polyfillSet[key]; });
 
 		return arrayOfPolyfills;
 	}
 
-	function setUpAliasesFromConfig(presetAliases) {
-		polyfillConfigAliases = presetAliases;
-	}
-
 	return {
-		initialiseAliasesFromConfig: setUpAliasesFromConfig,
-		resolvePolyfills: resolve
+		resolvePolyfills: resolve,
+		addResolver: function(func) {
+			aliasResolvers.push(func);
+			return this;
+		}
 	}
 }());
 
+/*
+	if (aliases) {
+	}
 
+	return [polyfill];
+
+	8?§
 /**
  * Apply a function to each element in the array and concatenate the result
  * of the function into a new array.

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 	});
 });
 
-var aliasResolver = AliasResolver.createDefault(aliases);
+AliasResolver.initialise(aliases);
 
 function getPolyfillString(options) {
 	var ua = useragent.lookup(options.uaString),
@@ -69,7 +69,7 @@ function getPolyfillString(options) {
 		ua.patch = '0';
 	}
 
-	var expandedPolyfillList = aliasResolver.resolve(options.polyfills);
+	var expandedPolyfillList = AliasResolver.resolvePolyfills(options.polyfills);
 
 	expandedPolyfillList.forEach(function(polyfill) {
 		var polyfillSource = sources[polyfill.name];

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ require('useragent/features');
 var polyfillSourceFolder = path.join(__dirname, '../polyfills');
 
 var sources = {},
-	aliases = {};
+	configuredAliases = {};
 
 fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 
@@ -43,15 +43,17 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 	// array is created and used for the value in the map.
 	config.aliases = config.aliases || [];
 	config.aliases.forEach(function(aliasName) {
-		if (aliases[aliasName]) {
-			aliases[aliasName].push(polyfillName);
+		if (configuredAliases[aliasName]) {
+			configuredAliases[aliasName].push(polyfillName);
 		} else {
-			aliases[aliasName] = [ polyfillName ];
+			configuredAliases[aliasName] = [ polyfillName ];
 		}
 	});
 });
 
-AliasResolver.initialise(aliases);
+AliasResolver.addResolver(function expandAliasFromConfig(polyfillIdentifierName) {
+	return configuredAliases[polyfillIdentifierName];
+});
 
 function getPolyfillString(options) {
 	var ua = useragent.lookup(options.uaString),

--- a/service/helpers.js
+++ b/service/helpers.js
@@ -9,9 +9,9 @@ module.exports = {
 			var nameAndFlags = name.split('|');
 			return {
 				flags:   nameAndFlags.slice(1).concat(additionalFlags),
-				name:    nameAndFlags[0],
-				aliasOf: nameAndFlags[0]
+				name:    nameAndFlags[0]
 			};
 		});
 	}
 };
+

--- a/service/index.js
+++ b/service/index.js
@@ -12,8 +12,7 @@ var polyfillio = require('../lib'),
 
 var argv = parseArgs(process.argv.slice(2));
 
-var aliasResolver = AliasResolver.createDefault(polyfillio.aliases),
-	port = argv.port || 3000,
+var port = argv.port || 3000,
 	metrics = new ServiceMetrics();
 
 

--- a/test/lib/test_aliases.js
+++ b/test/lib/test_aliases.js
@@ -1,0 +1,144 @@
+var assert  = require('assert');
+var AliasResolver = require('../../lib/aliases');
+
+describe("#resolvePolyfills(polyfills)", function() {
+
+	it("should take a list of polyfill objects and resolve each to potentially many other polyfill objects based on a sequence of resolution functions", function() {
+
+		// Initialise the resolver with a dictionary of names mapping to
+		// potentially many names (eg modernizr:es5array contains all the ES5
+		// array polyfills.
+		AliasResolver.initialise({
+			"alias_name_a": [ "resolved_name_a", "resolved_name_b" ],
+			"alias_name_b": [ "resolved_name_c", "resolved_name_d" ]
+		});
+
+		var resolvedPolyfills = AliasResolver.resolvePolyfills([{
+			name: "alias_name_a",
+			flags: []
+		}]);
+
+		assert.deepEqual([{
+				name: "resolved_name_a",
+				flags: [],
+				aliasOf: ["alias_name_a"]
+			},
+			{
+				name: "resolved_name_b",
+				flags: [],
+				aliasOf: ["alias_name_a"]
+			}
+		], resolvedPolyfills);
+	});
+
+	it("should remove duplicate polyfills once expanded and record which aliases included each polyfill once duplicates are removed", function() {
+		AliasResolver.initialise({
+			"alias_name_a": ["resolved_name_a", "resolved_name_b"],
+			"alias_name_b": ["resolved_name_c", "resolved_name_b"]
+		});
+
+		var resolvedPolyfills = AliasResolver.resolvePolyfills([{
+			name: "alias_name_a",
+			flags: []
+		},
+		{
+			name: "alias_name_b",
+			flags: []
+		}]);
+
+		assert.deepEqual([
+			{
+				name: "resolved_name_a",
+				flags: [],
+				aliasOf: ["alias_name_a"]
+			},
+			{
+				name: "resolved_name_b",
+				flags: [],
+				aliasOf: ["alias_name_a", "alias_name_b"]
+			},
+			{
+				name: "resolved_name_c",
+				flags: [],
+				aliasOf: ["alias_name_b"]
+			}
+		], resolvedPolyfills);
+	});
+
+	it("should pass flags from the aliases to their resolved counterparts", function() {
+		AliasResolver.initialise({
+			"alias_name_a": ["resolved_name_a", "resolved_name_b"],
+			"alias_name_b": ["resolved_name_c", "resolved_name_d"]
+		});
+
+		var resolvedPolyfills = AliasResolver.resolvePolyfills([
+			{
+				name: "alias_name_a",
+				flags: ["always"]
+			},
+			{
+				name: "alias_name_b",
+				flags: ["gated"]
+			}
+		]);
+
+		assert.deepEqual([
+			{
+				name: "resolved_name_a",
+				flags: ["always"],
+				aliasOf: ["alias_name_a"]
+			},
+			{
+				name: "resolved_name_b",
+				flags: ["always"],
+				aliasOf: ["alias_name_a"]
+			},
+			{
+				name: "resolved_name_c",
+				flags: ["gated"],
+				aliasOf: ["alias_name_b"]
+			},
+			{
+				name: "resolved_name_d",
+				flags: ["gated"],
+				aliasOf: ["alias_name_b"]
+			}
+		], resolvedPolyfills);
+	});
+
+	it("should concatenate duplicate polyfill's flags and aliases", function() {
+		AliasResolver.initialise({
+			"alias_name_a": ["resolved_name_a", "resolved_name_b"],
+			"alias_name_b": ["resolved_name_c", "resolved_name_b"]
+		});
+
+		var resolvedPolyfills = AliasResolver.resolvePolyfills([
+			{
+				name: "alias_name_a",
+				flags: ["always"]
+			},
+			{
+				name: "alias_name_b",
+				flags: ["gated"]
+			}
+		]);
+
+		assert.deepEqual([
+			{
+				name: "resolved_name_a",
+				flags: ["always"],
+				aliasOf: ["alias_name_a"]
+			},
+			{
+				name: "resolved_name_b",
+				flags: ["always", "gated"],
+				aliasOf: ["alias_name_a", "alias_name_b"]
+			},
+			{
+				name: "resolved_name_c",
+				flags: ["gated"],
+				aliasOf: ["alias_name_b"]
+			}
+		], resolvedPolyfills);
+	});
+});

--- a/test/lib/test_aliases.js
+++ b/test/lib/test_aliases.js
@@ -8,7 +8,7 @@ describe("#resolvePolyfills(polyfills)", function() {
 		// Initialise the resolver with a dictionary of names mapping to
 		// potentially many names (eg modernizr:es5array contains all the ES5
 		// array polyfills.
-		AliasResolver.initialise({
+		AliasResolver.initialiseAliasesFromConfig({
 			"alias_name_a": [ "resolved_name_a", "resolved_name_b" ],
 			"alias_name_b": [ "resolved_name_c", "resolved_name_d" ]
 		});
@@ -32,7 +32,7 @@ describe("#resolvePolyfills(polyfills)", function() {
 	});
 
 	it("should remove duplicate polyfills once expanded and record which aliases included each polyfill once duplicates are removed", function() {
-		AliasResolver.initialise({
+		AliasResolver.initialiseAliasesFromConfig({
 			"alias_name_a": ["resolved_name_a", "resolved_name_b"],
 			"alias_name_b": ["resolved_name_c", "resolved_name_b"]
 		});
@@ -66,7 +66,7 @@ describe("#resolvePolyfills(polyfills)", function() {
 	});
 
 	it("should pass flags from the aliases to their resolved counterparts", function() {
-		AliasResolver.initialise({
+		AliasResolver.initialiseAliasesFromConfig({
 			"alias_name_a": ["resolved_name_a", "resolved_name_b"],
 			"alias_name_b": ["resolved_name_c", "resolved_name_d"]
 		});
@@ -107,7 +107,7 @@ describe("#resolvePolyfills(polyfills)", function() {
 	});
 
 	it("should concatenate duplicate polyfill's flags and aliases", function() {
-		AliasResolver.initialise({
+		AliasResolver.initialiseAliasesFromConfig({
 			"alias_name_a": ["resolved_name_a", "resolved_name_b"],
 			"alias_name_b": ["resolved_name_c", "resolved_name_b"]
 		});

--- a/test/lib/test_aliases.js
+++ b/test/lib/test_aliases.js
@@ -1,6 +1,12 @@
 var assert  = require('assert');
 var AliasResolver = require('../../lib/aliases');
 
+var configuredAliases = {};
+
+AliasResolver.addResolver(function expandAliasFromConfig(polyfillIdentifierName) {
+	return configuredAliases[polyfillIdentifierName];
+});
+
 describe("#resolvePolyfills(polyfills)", function() {
 
 	it("should take a list of polyfill objects and resolve each to potentially many other polyfill objects based on a sequence of resolution functions", function() {
@@ -8,10 +14,10 @@ describe("#resolvePolyfills(polyfills)", function() {
 		// Initialise the resolver with a dictionary of names mapping to
 		// potentially many names (eg modernizr:es5array contains all the ES5
 		// array polyfills.
-		AliasResolver.initialiseAliasesFromConfig({
+		configuredAliases = {
 			"alias_name_a": [ "resolved_name_a", "resolved_name_b" ],
 			"alias_name_b": [ "resolved_name_c", "resolved_name_d" ]
-		});
+		};
 
 		var resolvedPolyfills = AliasResolver.resolvePolyfills([{
 			name: "alias_name_a",
@@ -32,10 +38,10 @@ describe("#resolvePolyfills(polyfills)", function() {
 	});
 
 	it("should remove duplicate polyfills once expanded and record which aliases included each polyfill once duplicates are removed", function() {
-		AliasResolver.initialiseAliasesFromConfig({
+		configuredAliases = {
 			"alias_name_a": ["resolved_name_a", "resolved_name_b"],
 			"alias_name_b": ["resolved_name_c", "resolved_name_b"]
-		});
+		};
 
 		var resolvedPolyfills = AliasResolver.resolvePolyfills([{
 			name: "alias_name_a",
@@ -66,10 +72,10 @@ describe("#resolvePolyfills(polyfills)", function() {
 	});
 
 	it("should pass flags from the aliases to their resolved counterparts", function() {
-		AliasResolver.initialiseAliasesFromConfig({
+		configuredAliases = {
 			"alias_name_a": ["resolved_name_a", "resolved_name_b"],
 			"alias_name_b": ["resolved_name_c", "resolved_name_d"]
-		});
+		};
 
 		var resolvedPolyfills = AliasResolver.resolvePolyfills([
 			{
@@ -107,10 +113,10 @@ describe("#resolvePolyfills(polyfills)", function() {
 	});
 
 	it("should concatenate duplicate polyfill's flags and aliases", function() {
-		AliasResolver.initialiseAliasesFromConfig({
+		configuredAliases = {
 			"alias_name_a": ["resolved_name_a", "resolved_name_b"],
 			"alias_name_b": ["resolved_name_c", "resolved_name_b"]
-		});
+		};
 
 		var resolvedPolyfills = AliasResolver.resolvePolyfills([
 			{

--- a/test/lib/test_aliases.js
+++ b/test/lib/test_aliases.js
@@ -147,4 +147,44 @@ describe("#resolvePolyfills(polyfills)", function() {
 			}
 		], resolvedPolyfills);
 	});
+
+	it("should transfer only the first, specified alias to the final resolved polyfill identifier", function() {
+		configuredAliases = {
+			"alias_name_a": ["resolved_name_a", "resolved_name_b"],
+			"alias_name_b": ["resolved_name_c", "resolved_name_b"]
+		};
+
+		AliasResolver.clearResolvers();
+		AliasResolver.addResolver(function(polyfillIdentifierName) {
+
+			// Map only first_alias_name_a to another alias
+			if (polyfillIdentifierName === "first_alias_name_a") {
+				return ["alias_name_a"];
+			}
+
+			return [polyfillIdentifierName];
+		}).addResolver(function(polyfillIdentifierName) {
+			return configuredAliases[polyfillIdentifierName];
+		});
+
+		var resolvedPolyfills = AliasResolver.resolvePolyfills([
+			{
+				name: "first_alias_name_a",
+				flags: ["always"]
+			}
+		]);
+
+		assert.deepEqual([
+			{
+				name: "resolved_name_a",
+				flags: ["always"],
+				aliasOf: ["first_alias_name_a"]
+			},
+			{
+				name: "resolved_name_b",
+				flags: ["always"],
+				aliasOf: ["first_alias_name_a"]
+			}
+		], resolvedPolyfills);
+	});
 });


### PR DESCRIPTION
Adds tests for the alias resolution logic which revealed some flaws:
- Now only a single AliasResolver module can be used effectively.  There isn't much point in being able to create more than one in any context
- If duplicate polyfills are encountered following name resolution, all applicable flags are applied and each separate alias is recorded
- Polyfills included via multiple aliases record each alias that caused its inclusion
- Correctly removes duplicate polyfill entries (expanding aliases and flags as above)

This keeps much of the same logic:
1. For each resolver function..
2. Apply the resolver function to each Polyfill - (polyfill -> [polyfills])
3. Flatten the result
4. Remove duplicates and expand aliases and flags
5. Repeat until all resolver functions have run (in order).
