### PR TITLE
Combine the different 'matches' fills. 

### DIFF
--- a/polyfills/Element.prototype.matches/config.json
+++ b/polyfills/Element.prototype.matches/config.json
@@ -6,12 +6,12 @@
 		"opera mini": "*",
 		"opera mobile": "*",
 		"android": "*",
-		"blackBerry": "*",
+		"blackberry": "*",
 		"chrome": "1 - 33",
 		"chrome iOS": "*",
 		"opera": "15",
 		"safari": "4 - *",
-		"safari iOS": "*"
+		"safari ios": "*"
 	},
 	"dependencies": ["Window.polyfill.ie7"]
 }

--- a/polyfills/Element.prototype.matches/config.json
+++ b/polyfills/Element.prototype.matches/config.json
@@ -1,6 +1,17 @@
 {
 	"browsers": {
-		"ie": "6 - 8"
+		"ie": "6 - *",
+		"firefox": "*",
+		"opera": "11.5 - 12.1",
+		"opera mini": "*",
+		"opera mobile": "*",
+		"android": "*",
+		"blackBerry": "*",
+		"chrome": "1 - 33",
+		"chrome iOS": "*",
+		"opera": "15",
+		"safari": "4 - *",
+		"safari iOS": "*"
 	},
 	"dependencies": ["Window.polyfill.ie7"]
 }

--- a/polyfills/Element.prototype.matches/polyfill.js
+++ b/polyfills/Element.prototype.matches/polyfill.js
@@ -1,5 +1,11 @@
 // Element.prototype.matches, Element.prototype.matchesSelector
-Element.prototype.matches = function matches(selector) {
+Element.prototype.matches = (Element.prototype.matches ||
+				Element.prototype.matchesSelector ||
+				Element.prototype.webkitMatchesSelector ||
+				Element.prototype.msMatchesSelector ||
+				Element.prototype.mozMatchesSelector ||
+				Element.prototype.oMatchesSelector ||
+function matches(selector) {
 	var
 	element = this,
 	elements = (element.document || element.ownerDocument).querySelectorAll(selector),
@@ -10,4 +16,4 @@ Element.prototype.matches = function matches(selector) {
 	}
 
 	return elements[index] ? true : false;
-};
+});


### PR DESCRIPTION
As a temporary solution to #57 and #59, include the un-prefixing of the API in the polyfill.  This is used at the moment as the idea of linked polyfills is not complete.  I envisage this will be reverted once #59 is complete.
