### PR TITLE
Add browser names mappings from ua-parser to caniuse names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ All polyfills are located in the polyfills directory, with one subdirectory per 
 
 The config.json file may contain any of the following keys:
 
-* `browsers`: Object, one key per browser family name (see [browser names](/#browser-names)), with the value forming either a range or a list of specific versions separated by double pipes. See [node-semver ranges](https://github.com/npm/node-semver#ranges).
+* `browsers`: Object, one key per browser family name (see [browser names](#browser-names)), with the value forming either a range or a list of specific versions separated by double pipes. See [node-semver ranges](https://github.com/npm/node-semver#ranges).
 * `aliases`: Array, a list of alternate names for referencing the polyfill.  In the example Modernizr names are explicitly namespaced.
 * `dependencies`: Array, a list of canonical polyfill names for polyfills that must be included prior to this one.
 * `author`: Object, metadata about the author of the polyfill, following [NPM convention](https://www.npmjs.org/doc/json.html#people-fields-author-contributors)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ support using the `browsers` key.
 | `ie`       | Internet Explorer        |
 | `ie_mob`   | Internet Explorer Mobile |
 | `chrome`   | Chrome                   |
+| `ios_chr`  | Chrome on iOS            |
 | `safari`   | Safari                   |
 | `ios_saf`  | Safari on iOS            |
 | `firefox`  | Firefox                  |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ All polyfills are located in the polyfills directory, with one subdirectory per 
 
 The config.json file may contain any of the following keys:
 
-* `browsers`: Object, one key per browser family, with the value forming either a range or a list of specific versions separated by double pipes.
+* `browsers`: Object, one key per browser family name (see [browser names](/#browser-names)), with the value forming either a range or a list of specific versions separated by double pipes. See [node-semver ranges](https://github.com/npm/node-semver#ranges).
 * `aliases`: Array, a list of alternate names for referencing the polyfill.  In the example Modernizr names are explicitly namespaced.
 * `dependencies`: Array, a list of canonical polyfill names for polyfills that must be included prior to this one.
 * `author`: Object, metadata about the author of the polyfill, following [NPM convention](https://www.npmjs.org/doc/json.html#people-fields-author-contributors)
@@ -98,3 +98,22 @@ Example:
 	"license": "Zlib"
 }
 ```
+
+### Browser names
+
+The short names should be used in the `config.json` to configure the browser
+support using the `browsers` key.
+
+| Short name | User Agent Name          |
+|:----------:|:-------------------------|
+| `ie`       | Internet Explorer        |
+| `ie_mob`   | Internet Explorer Mobile |
+| `chrome`   | Chrome                   |
+| `safari`   | Safari                   |
+| `ios_saf`  | Safari on iOS            |
+| `firefox`  | Firefox                  |
+| `android`  | Android Browser          |
+| `opera`    | Opera                    |
+| `op_mob`   | Opera Mobile             |
+| `op_mini`  | Opera Mini               |
+| `bb`       | Blackberry               |

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -7,6 +7,7 @@
  *
  * To add a new mapping add the UA name to the appropriate key.
  */
+var useragent = require('useragent');
 
 var agentmappings = {
 	"bb": [
@@ -63,13 +64,26 @@ Object.keys(agentmappings).forEach(function(caniuseAgentName) {
 	});
 });
 
+module.exports = function(uaString) {
+	var ua = useragent.lookup(uaString);
+
+	// Browsers don't really use semantic versioning but tend to at least
+	// have a major and minor version.  This normalises the patch version so that
+	// semantic version comparison is consistent.
+	if (!isNumeric(ua.patch)) {
+		ua.patch = '0';
+	}
+
+	// Patch ua.family with the normalised name
+	ua.family = agentlist[ua.family.toLowerCase()] || ua.family;
+
+	return ua;
+}
+
 /**
- * Return a normalized name for the user agent, if there is no normalized name
- * the name is returned as is, without modification.
- *
- * @param {string} agentname The name of the user agent to normalize.
- * @returns {string} A normalized user agent name.
+ * jQuery: isNumeric
+ * https://github.com/jquery/jquery/blob/bbdfbb4ee859fe9319b348d88120ddc2c9efbd63/src/core.js#L212
  */
-module.exports = function(agentname) {
-	return agentlist[agentname] || agentname;
-};
+function isNumeric(obj) {
+	return !Array.isArray(obj) && (((obj- parseFloat(obj)) + 1) >= 0);
+}

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,15 +1,58 @@
 /**
- * Helper module used to alias browser names parsed out of the 'useragent'
- * module to the equivalent names used in the config.json for each polyfill.
- * Should always be lowercase values as it makes comparisons easier.
+ * Create mappings between the names parsed from useragent (based on
+ * https://github.com/tobie/ua-parser/blob/master/regexes.yaml) to caniuse
+ * name equivalents.
+ *
+ * Each caniuse name can match against many names.
+ *
+ * To add a new mapping add the UA name to the appropriate key.
  */
 
-var agentlist = {
-	"chromium": "chrome",
-	"mobile safari": "safari ios",
-	"firefox beta": "firefox"
+var agentmappings = {
+	"firefox": [
+		"pale moon (firefox variant)",
+		"firefox mobile",
+		"firefox namoroka",
+		"firefox shiretoko",
+		"firefox minefield",
+		"firefox alpha",
+		"firefox beta",
+		"microb",
+		"mozilladeveloperpreview"
+	],
+	"opera": [
+		"opera tablet"
+	],
+	"op_mob": [
+		"opera mobile"
+	],
+	"op_mini": [
+		"opera mini"
+	],
+	"chrome": [
+		"chrome mobile ios",
+		"chrome mobile",
+		"chrome frame",
+		"chromium"
+	],
+	"ie_mob": [
+		"ie mobile"
+	],
+	"ios_saf": [
+		"mobile safari"
+	]
 };
 
+var agentlist = {};
+
+
+// Invert the mappings above mapping each user agent to the caniuse name for
+// faster lookup in agent list
+Object.keys(agentmappings).forEach(function(caniuseAgentName) {
+	agentmappings[caniuseAgentName].forEach(function(userAgentName) {
+		agentlist[userAgentName] = caniuseAgentName;
+	});
+});
 
 /**
  * Return a normalized name for the user agent, if there is no normalized name

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -9,6 +9,10 @@
  */
 
 var agentmappings = {
+	"bb": [
+		"blackberry webkit",
+		"blackberry"
+	],
 	"firefox": [
 		"pale moon (firefox variant)",
 		"firefox mobile",
@@ -37,6 +41,9 @@ var agentmappings = {
 	],
 	"ie_mob": [
 		"ie mobile"
+	],
+	"ie": [
+		"ie large screen"
 	],
 	"ios_saf": [
 		"mobile safari"

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -34,7 +34,6 @@ var agentmappings = {
 		"opera mini"
 	],
 	"chrome": [
-		"chrome mobile ios",
 		"chrome mobile",
 		"chrome frame",
 		"chromium"
@@ -44,6 +43,9 @@ var agentmappings = {
 	],
 	"ie": [
 		"ie large screen"
+	],
+	"ios_chr": [
+		"chrome mobile ios"
 	],
 	"ios_saf": [
 		"mobile safari"

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,9 @@
 var fs = require('fs'),
 	path = require('path'),
-	useragent = require('useragent'),
 	uglify    = require('uglify-js'),
 	tsort     = require('tsort'),
 	AliasResolver = require('./aliases'),
-	lookupAgent = require('./agent');
+	getUserAgentInfo = require('./agent');
 
 // Load additional useragent features: primarily to use: agent.satisfies to
 // test a browser version against a semver string
@@ -77,24 +76,17 @@ AliasResolver.addResolver(function (polyfillIdentifierName) {
 });
 
 function getPolyfillString(options) {
-	var ua = useragent.lookup(options.uaString),
-		uaFamily = lookupAgent(ua.family.toLowerCase()),
+	var ua = getUserAgentInfo(options.uaString),
 		explainerComment = options.minify ? [
 			'Rerun without minification for verbose metadata'
 		] : [
 			'Polyfill bundle includes the following polyfills.  For detailed credits and licence information see http://github.com/financial-times/polyfill-service.',
 			'',
-			'Detected: ' + uaFamily + '/' + ua.toVersion(),
+			'Detected: ' + ua.family + '/' + ua.toVersion(),
 			''
 		],
 		currentPolyfills = {};
 
-	// Browsers don't really use semantic versioning but tend to at least
-	// have a major and minor version.  This normalises the patch version so that
-	// semantic version comparison is consistent.
-	if (!isNumeric(ua.patch)) {
-		ua.patch = '0';
-	}
 
 	var desired = options.polyfills
 
@@ -128,7 +120,7 @@ function getPolyfillString(options) {
 				return;
 			}
 
-			var browserVersion = polyfillConfig.browsers[uaFamily];
+			var browserVersion = polyfillConfig.browsers[ua.family];
 			if (!(browserVersion && ua.satisfies(browserVersion))) {
 				return;
 			}
@@ -180,11 +172,3 @@ function getPolyfillString(options) {
 module.exports = {
 	getPolyfills: getPolyfillString
 };
-
-/**
- * jQuery: isNumeric
- * https://github.com/jquery/jquery/blob/bbdfbb4ee859fe9319b348d88120ddc2c9efbd63/src/core.js#L212
- */
-function isNumeric(obj) {
-	return !Array.isArray(obj) && (((obj- parseFloat(obj)) + 1) >= 0);
-}

--- a/polyfills/Element.prototype.matches.o/config.json
+++ b/polyfills/Element.prototype.matches.o/config.json
@@ -1,7 +1,7 @@
 {
 	"browsers": {
 		"opera": "11.5 - 12.1",
-		"opera mini": "*",
-		"opera mobile": "*"
+		"op_mini": "*",
+		"op_mob": "*"
 	}
 }

--- a/polyfills/Element.prototype.matches.webkit/config.json
+++ b/polyfills/Element.prototype.matches.webkit/config.json
@@ -1,11 +1,11 @@
 {
 	"browsers": {
 		"android": "*",
-		"blackBerry": "*",
+		"bb": "*",
 		"chrome": "1 - 33",
-		"chrome iOS": "*",
+		"ios_chr": "*",
 		"opera": "15",
 		"safari": "4 - *",
-		"safari iOS": "*"
+		"ios_saf": "*"
 	}
 }

--- a/polyfills/Element.prototype.matches/config.json
+++ b/polyfills/Element.prototype.matches/config.json
@@ -3,15 +3,15 @@
 		"ie": "6 - *",
 		"firefox": "*",
 		"opera": "11.5 - 12.1",
-		"opera mini": "*",
-		"opera mobile": "*",
+		"op_mini": "*",
+		"op_mob": "*",
 		"android": "*",
-		"blackberry": "*",
+		"bb": "*",
 		"chrome": "1 - 33",
-		"chrome iOS": "*",
+		"ios_chr": "*",
 		"opera": "15",
 		"safari": "4 - *",
-		"safari ios": "*"
+		"ios_saf": "*"
 	},
 	"dependencies": ["Window.polyfill.ie7"]
 }

--- a/polyfills/Element.prototype.mutation/config.json
+++ b/polyfills/Element.prototype.mutation/config.json
@@ -1,14 +1,14 @@
 {
 	"browsers": {
 		"android": "*",
-		"blackBerry": "*",
-		"chrome ios": "*",
+		"bb": "*",
+		"ios_chr": "*",
 		"firefox": "3.6 - *",
 		"ie": "9 - *",
 		"opera": "11.5 - 12.1",
-		"opera mini": "*",
+		"op_mini": "*",
 		"safari": "4 - *",
-		"safari ios": "*"
+		"ios_saf": "*"
 	},
 	"dependencies": ["Window.polyfill.ie7"]
 }

--- a/polyfills/Object.defineProperty/config.json
+++ b/polyfills/Object.defineProperty/config.json
@@ -2,6 +2,6 @@
 	"browsers": {
 		"firefox": "3.6",
 		"safari": "4",
-		"safari ios": "4.3"
+		"ios_saf": "4.3"
 	}
 }

--- a/polyfills/Object.is/config.json
+++ b/polyfills/Object.is/config.json
@@ -1,14 +1,14 @@
 {
 	"browsers": {
 		"android": "*",
-		"blackberry": "*",
+		"bb": "*",
 		"chrome": "1 - 29",
 		"firefox": "3.6 - 21",
 		"ie": "*",
 		"opera": "*",
-		"opera mini": "*",
-		"opera mobile": "*",
+		"op_mini": "*",
+		"op_mob": "*",
 		"safari": "*",
-		"safari ios": "*"
+		"ios_saf": "*"
 	}
 }

--- a/polyfills/Window.prototype.devicePixelRatio.iossafari6/config.json
+++ b/polyfills/Window.prototype.devicePixelRatio.iossafari6/config.json
@@ -1,5 +1,5 @@
 {
 	"browsers": {
-		"ios safari": "*"
+		"ios_saf": "*"
 	}
 }

--- a/polyfills/Window.prototype.matchMedia/config.json
+++ b/polyfills/Window.prototype.matchMedia/config.json
@@ -5,8 +5,8 @@
 		"ie": "6 - 9",
 		"firefox": "3.6 - 5",
 		"opera": "11.5 - 12.1",
-		"opera mini": "*",
-		"opera mobile": "10 - 12",
+		"op_mini": "*",
+		"op_mob": "10 - 12",
 		"safari": "4 - 5"
 	},
 	"dependencies": ["Window.prototype.Event.firefox5", "Window.prototype.Event.ie8", "Window.prototype.Event"]

--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -1,13 +1,13 @@
 {
 	"browsers": {
-		"blackberry": "7",
+		"bb": "7",
 		"chrome": "1 - 9",
 		"ie": "6 - 9",
-		"ios safari": "3.2 - 5.1",
+		"ios_saf": "3.2 - 5.1",
 		"firefox": "3.6",
 		"opera": "9 - 12.1",
-		"opera mini": "5 - 7",
-		"opera mobile": "10 - 12.1",
+		"op_mini": "5 - 7",
+		"op_mob": "10 - 12.1",
 		"safari": "3.1 - 5.1"
 	},
 	"license": "requestAnimationFrame polyfill by Erik Möller, fixes from Paul Irish, Tino Zijdel, and Jonathan Neal"


### PR DESCRIPTION
This covers all of the caniuse names and the possible mappings to them from the ua-parser.
Closes #47

This also adds `ios_chr` (inline with the caniuse naming convention) for Chrome on iOS, which was specifically mentioned in some config.json files with different version ranges than plain `chrome`.
