### PR TITLE
Adds a selection of modernizr aliases

### DIFF
--- a/polyfills/AudioContext/config.json
+++ b/polyfills/AudioContext/config.json
@@ -1,6 +1,6 @@
 {
-	"caniuse": "audio-api",
 	"aliases": [
-		"modernizr:webaudio"
+		"modernizr:webaudio",
+		"caniuse:audio-api"
 	]
 }

--- a/polyfills/Element.prototype.classList/config.json
+++ b/polyfills/Element.prototype.classList/config.json
@@ -3,7 +3,7 @@
 		"ie": "8 - 9",
 		"safari": "4"
 	},
-	"dependencies": ["Window.polyfill.ie7", "Object.defineProperties"],
+	"dependencies": ["Window.polyfill.ie7", "Object.defineProperties", "Window.prototype.DOMTokenList"],
 	"aliases": [
 		"modernizr:classlist"
 	]

--- a/polyfills/Element.prototype.matches.moz/config.json
+++ b/polyfills/Element.prototype.matches.moz/config.json
@@ -1,5 +1,8 @@
 {
 	"browsers": {
 		"firefox": "*"
-	}
+	},
+	"aliases": [
+		"caniuse:matchesselector"
+	]
 }

--- a/polyfills/Element.prototype.matches.ms/config.json
+++ b/polyfills/Element.prototype.matches.ms/config.json
@@ -1,5 +1,8 @@
 {
 	"browsers": {
 		"ie": "9 - *"
-	}
+	},
+	"aliases": [
+		"caniuse:matchesselector"
+	]
 }

--- a/polyfills/Element.prototype.matches.o/config.json
+++ b/polyfills/Element.prototype.matches.o/config.json
@@ -3,5 +3,8 @@
 		"opera": "11.5 - 12.1",
 		"op_mini": "*",
 		"op_mob": "*"
-	}
+	},
+	"aliases": [
+		"caniuse:matchesselector"
+	]
 }

--- a/polyfills/Element.prototype.matches.webkit/config.json
+++ b/polyfills/Element.prototype.matches.webkit/config.json
@@ -7,5 +7,8 @@
 		"opera": "15",
 		"safari": "4 - *",
 		"ios_saf": "*"
-	}
+	},
+	"aliases": [
+		"caniuse:matchesselector"
+	]
 }

--- a/polyfills/Element.prototype.matches/config.json
+++ b/polyfills/Element.prototype.matches/config.json
@@ -13,5 +13,8 @@
 		"safari": "4 - *",
 		"ios_saf": "*"
 	},
+	"aliases": [
+		"caniuse:matchesselector"
+	],
 	"dependencies": ["Window.polyfill.ie7"]
 }

--- a/polyfills/Element.prototype.placeholder.ie7/config.json
+++ b/polyfills/Element.prototype.placeholder.ie7/config.json
@@ -2,5 +2,9 @@
 	"browsers": {
 		"ie": "6 - 7"
 	},
+	"aliases": [
+		"modernizr:placeholder",
+		"caniuse:input-placeholder"
+	],
 	"dependencies": ["Window.polyfill.ie7"]
 }

--- a/polyfills/Element.prototype.placeholder/config.json
+++ b/polyfills/Element.prototype.placeholder/config.json
@@ -2,5 +2,9 @@
 	"browsers": {
 		"ie": "8"
 	},
+	"aliases": [
+		"modernizr:placeholder",
+		"caniuse:input-placeholder"
+	],
 	"dependencies": ["Object.defineProperty"]
 }

--- a/polyfills/Function.prototype.bind/config.json
+++ b/polyfills/Function.prototype.bind/config.json
@@ -3,5 +3,8 @@
 		"ie": "6 - 8",
 		"firefox": "3.6",
 		"safari": "4 - 5.1"
-	}
+	},
+	"aliases": [
+		"modernizr:es5function"
+	]
 }

--- a/polyfills/Navigator.prototype.geolocation/config.json
+++ b/polyfills/Navigator.prototype.geolocation/config.json
@@ -3,5 +3,9 @@
 		"ie": "6 - 8",
 		"opera": "15",
 		"safari": "4"
-	}
+	},
+	"aliases": [
+		"modernizr:geolocation",
+		"caniuse:geolocation"
+	]
 }

--- a/polyfills/Object.create.ie7/config.json
+++ b/polyfills/Object.create.ie7/config.json
@@ -2,5 +2,8 @@
 	"browsers": {
 		"ie": "6 - 7"
 	},
+	"aliases": [
+		"modernizr:es5object"
+	],
 	"dependencies": ["Object.defineProperties"]
 }

--- a/polyfills/Object.create/config.json
+++ b/polyfills/Object.create/config.json
@@ -4,5 +4,8 @@
 		"firefox": "3.6",
 		"safari": "4"
 	},
+	"aliases": [
+		"modernizr:es5object"
+	],
 	"dependencies": ["Object.defineProperties"]
 }

--- a/polyfills/Object.defineProperties/config.json
+++ b/polyfills/Object.defineProperties/config.json
@@ -2,5 +2,8 @@
 	"browsers": {
 		"ie": "6 - 8"
 	},
+	"aliases": [
+		"modernizr:es5object"
+	],
 	"dependencies": ["Object.defineProperty.ie7", "Object.defineProperty.ie8", "Object.defineProperty"]
 }

--- a/polyfills/Object.defineProperty.ie7/config.json
+++ b/polyfills/Object.defineProperty.ie7/config.json
@@ -1,5 +1,8 @@
 {
 	"browsers": {
 		"ie": "6 - 7"
-	}
+	},
+	"aliases": [
+		"modernizr:es5object"
+	]
 }

--- a/polyfills/Object.defineProperty.ie8/config.json
+++ b/polyfills/Object.defineProperty.ie8/config.json
@@ -1,5 +1,8 @@
 {
 	"browsers": {
 		"ie": "8"
-	}
+	},
+	"aliases": [
+		"modernizr:es5object"
+	]
 }

--- a/polyfills/Object.defineProperty/config.json
+++ b/polyfills/Object.defineProperty/config.json
@@ -3,5 +3,8 @@
 		"firefox": "3.6",
 		"safari": "4",
 		"ios_saf": "4.3"
-	}
+	},
+	"aliases": [
+		"modernizr:es5object"
+	]
 }

--- a/polyfills/Object.getOwnPropertyNames/config.json
+++ b/polyfills/Object.getOwnPropertyNames/config.json
@@ -3,5 +3,8 @@
 		"ie": "6 - 8",
 		"firefox": "3.6",
 		"safari": "4"
-	}
+	},
+	"aliases": [
+		"modernizr:es5object"
+	]
 }

--- a/polyfills/Object.getPrototypeOf/config.json
+++ b/polyfills/Object.getPrototypeOf/config.json
@@ -3,5 +3,8 @@
 		"ie": "6 - 8",
 		"firefox": "3.6",
 		"safari": "4"
-	}
+	},
+	"aliases": [
+		"modernizr:es5object"
+	]
 }

--- a/polyfills/Object.is/config.json
+++ b/polyfills/Object.is/config.json
@@ -10,5 +10,8 @@
 		"op_mob": "*",
 		"safari": "*",
 		"ios_saf": "*"
-	}
+	},
+	"aliases": [
+		"modernizr:es6object"
+	]
 }

--- a/polyfills/Object.keys/config.json
+++ b/polyfills/Object.keys/config.json
@@ -3,5 +3,8 @@
 		"ie": "6 - 8",
 		"firefox": "3.6",
 		"safari": "4"
-	}
+	},
+	"aliases": [
+		"modernizr:es5object"
+	]
 }

--- a/polyfills/Promise/config.json
+++ b/polyfills/Promise/config.json
@@ -1,1 +1,6 @@
-{}
+{
+	"aliases": [
+		"modernizr:promises",
+		"caniuse:promises"
+	]
+}

--- a/polyfills/String.prototype.contains/config.json
+++ b/polyfills/String.prototype.contains/config.json
@@ -1,1 +1,5 @@
-{}
+{
+	"aliases": [
+		"modernizr:es6string"
+	]
+}

--- a/polyfills/String.prototype.endsWith/config.json
+++ b/polyfills/String.prototype.endsWith/config.json
@@ -1,1 +1,5 @@
-{}
+{
+	"aliases": [
+		"modernizr:es6string"
+	]
+}

--- a/polyfills/String.prototype.repeat/config.json
+++ b/polyfills/String.prototype.repeat/config.json
@@ -1,3 +1,5 @@
 {
-	"modernir:es6string"
+	"aliases": [
+		"modernir:es6string"
+	]
 }

--- a/polyfills/String.prototype.repeat/config.json
+++ b/polyfills/String.prototype.repeat/config.json
@@ -1,1 +1,3 @@
-{}
+{
+	"modernir:es6string"
+}

--- a/polyfills/String.prototype.repeat/config.json
+++ b/polyfills/String.prototype.repeat/config.json
@@ -1,5 +1,5 @@
 {
 	"aliases": [
-		"modernir:es6string"
+		"modernizr:es6string"
 	]
 }

--- a/polyfills/String.prototype.startsWith/config.json
+++ b/polyfills/String.prototype.startsWith/config.json
@@ -1,1 +1,5 @@
-{}
+{
+	"aliases": [
+		"modernizr:es6string"
+	]
+}

--- a/polyfills/String.prototype.trim/config.json
+++ b/polyfills/String.prototype.trim/config.json
@@ -2,5 +2,8 @@
 	"browsers": {
 		"ie": "6 - 8",
 		"safari": "4"
-	}
+	},
+	"aliases": [
+		"modernizr:es5string"
+	]
 }

--- a/polyfills/Window.prototype.Event.hashchange/config.json
+++ b/polyfills/Window.prototype.Event.hashchange/config.json
@@ -3,5 +3,9 @@
 		"ie": "6 - 8",
 		"safari": "4"
 	},
+	"aliases": [
+		"modernizr:hashchange",
+		"caniuse:hashchange"
+	],
 	"dependencies": ["Window.prototype.Event.ie8"]
 }

--- a/polyfills/Window.prototype.Event.ie8.DOMContentLoaded/config.json
+++ b/polyfills/Window.prototype.Event.ie8.DOMContentLoaded/config.json
@@ -2,5 +2,8 @@
 	"browsers": {
 		"ie": "6 - 8"
 	},
+	"aliases": [
+		"caniuse:domcontentloaded"
+	],
 	"dependencies": ["Window.prototype.Event.ie8"]
 }

--- a/polyfills/Window.prototype.JSON/config.json
+++ b/polyfills/Window.prototype.JSON/config.json
@@ -2,6 +2,10 @@
 	"browsers": {
 		"ie": "6 - 7"
 	},
+	"aliases": [
+		"modernizr:json",
+		"caniuse:json"
+	],
 	"license": "MIT Asen Bozhilov JSON.parse (https://github.com/abozhilov/json)",
 	"dependencies": ["Window.polyfill.ie7"]
 }

--- a/polyfills/Window.prototype.base64/config.json
+++ b/polyfills/Window.prototype.base64/config.json
@@ -2,6 +2,9 @@
 	"browsers": {
 		"ie": "6 - 9"
 	},
+	"aliases": [
+		"caniuse:datauri"
+	],
 	"license": "MIT David Lindquist (http://www.webtoolkit.info/javascript-base64.html), Andrew Dodson (drew81.com)",
 	"dependencies": ["Window.polyfill.ie7"]
 }

--- a/polyfills/Window.prototype.localStorage.ie7/config.json
+++ b/polyfills/Window.prototype.localStorage.ie7/config.json
@@ -2,5 +2,9 @@
 	"browsers": {
 		"ie": "6 - 7"
 	},
+	"aliases": [
+		"modernizr:localstorage",
+		"caniuse:namevalue-storage"
+	],
 	"dependencies": ["Window.polyfill.ie7"]
 }

--- a/polyfills/Window.prototype.matchMedia/config.json
+++ b/polyfills/Window.prototype.matchMedia/config.json
@@ -9,5 +9,8 @@
 		"op_mob": "10 - 12",
 		"safari": "4 - 5"
 	},
+	"aliases": [
+		"caniuse:matchmedia"
+	],
 	"dependencies": ["Window.prototype.Event.firefox5", "Window.prototype.Event.ie8", "Window.prototype.Event"]
 }

--- a/polyfills/requestAnimationFrame.moz/config.json
+++ b/polyfills/requestAnimationFrame.moz/config.json
@@ -1,5 +1,9 @@
 {
 	"browsers": {
 		"firefox": "4 - 22"
-	}
+	},
+	"aliases": [
+		"modernizr:requestanimationframe",
+		"caniuse:requestanimationframe"
+	]
 }

--- a/polyfills/requestAnimationFrame.webkit/config.json
+++ b/polyfills/requestAnimationFrame.webkit/config.json
@@ -2,5 +2,9 @@
 	"browsers": {
 		"chrome": "10 - 23",
 		"safari": "6"
-	}
+	},
+	"aliases": [
+		"modernizr:requestanimationframe",
+		"caniuse:requestanimationframe"
+	]
 }

--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -10,5 +10,9 @@
 		"op_mob": "10 - 12.1",
 		"safari": "3.1 - 5.1"
 	},
+	"aliases": [
+		"modernizr:requestanimationframe",
+		"caniuse:requestanimationframe"
+	],
 	"license": "requestAnimationFrame polyfill by Erik Möller, fixes from Paul Irish, Tino Zijdel, and Jonathan Neal"
 }


### PR DESCRIPTION
Adds a range of Modernizr and caniuse aliases to polyfills/features.  Not all polyfills have a Modernizr or caniuse equivalent, in these cases no alias has been configured and we should write a test, send a pull request to Modernizr, and then configure the alias.

Closes #3 
