### PR TITLE
Expand namespaced polyfill names separated by dot separators

### DIFF
--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -45,10 +45,12 @@ module.exports = (function() {
 			// For each polyfill identifier name, apply the aliases and flags
 			// and return an array of Polyfill Identifier Objects
 			return polyfillIdentifierNames.map(function(name) {
+				var aliasOf = polyfillIdentifier.aliasOf ||	(polyfillIdentifier.name === name ? [] : [polyfillIdentifier.name]);
+
 				return {
 					name: name,
 					flags: polyfillIdentifier.flags,
-					aliasOf: polyfillIdentifier.aliasOf || [polyfillIdentifier.name]
+					aliasOf: aliasOf
 				};
 			});
 		});

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -45,7 +45,10 @@ module.exports = (function() {
 			// For each polyfill identifier name, apply the aliases and flags
 			// and return an array of Polyfill Identifier Objects
 			return polyfillIdentifierNames.map(function(name) {
-				var aliasOf = polyfillIdentifier.aliasOf ||	(polyfillIdentifier.name === name ? [] : [polyfillIdentifier.name]);
+				// It is possible that the name of an alias may also be the
+				// name of a polyfill.  In this case avoid setting an alias of
+				// itself
+				var aliasOf = polyfillIdentifier.aliasOf || (polyfillIdentifier.name === name ? [] : [polyfillIdentifier.name]);
 
 				return {
 					name: name,

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,9 +86,12 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 	}).addResolver(function(polyfillIdentifierName) {
 		// Expand a polyfill name i.e. Element.prototype becomes Element.prototype.* etc
 
-		// Append a dot separator to the polyfill name before testing 'startsWith'
-		var polyfillIdentifierNameAsNamespace = polyfillIdentifierName + ".";
-		var expandedPolyfillNames = Object.keys(sources).filter(function(canonicalSourceName) { return canonicalSourceName.startsWith(polyfillIdentifierNameAsNamespace); });
+		// Append a dot separator to the polyfill name before testing 'startsWith' if it does not already end with a dot.
+		var polyfillIdentifierNameAsNamespace = polyfillIdentifierName.replace(/(\.)?$/, '.') + '.';
+
+		var expandedPolyfillNames = Object.keys(sources).filter(function(canonicalSourceName) {
+			return canonicalSourceName.startsWith(polyfillIdentifierNameAsNamespace);
+		});
 
 		if (expandedPolyfillNames.length === 0) {
 			return undefined;

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,11 @@ var fs = require('fs'),
 	AliasResolver = require('./aliases'),
 	getUserAgentInfo = require('./agent');
 
+// Polyfill String.prototype.startsWith
+if (!String.prototype.startsWith) {
+	require('../polyfills/String.prototype.startsWith/polyfill');
+}
+
 // Load additional useragent features: primarily to use: agent.satisfies to
 // test a browser version against a semver string
 require('useragent/features');
@@ -70,10 +75,32 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 	});
 });
 
-AliasResolver.addResolver(function (polyfillIdentifierName) {
-	// If an name can not be resolved to anything return undefined
-	return configuredAliases[polyfillIdentifierName] || undefined;
-});
+// Set up AliasResolvers: Each function is applied to a polyfill name, the
+// function should then return an array of new strings that represent the name
+// or undefined to indicate that the name can not be expanded
+(function initAliasResolvers() {
+
+	AliasResolver.addResolver(function (polyfillIdentifierName) {
+		// If an name can not be resolved to anything return undefined
+		return configuredAliases[polyfillIdentifierName] || undefined;
+	}).addResolver(function(polyfillIdentifierName) {
+		// Expand a polyfill name i.e. Element.prototype becomes Element.prototype.* etc
+
+		// Append a dot separator to the polyfill name before testing 'startsWith'
+		var polyfillIdentifierNameAsNamespace = polyfillIdentifierName + ".";
+		var expandedPolyfillNames = Object.keys(sources).filter(function(canonicalSourceName) { return canonicalSourceName.startsWith(polyfillIdentifierNameAsNamespace); });
+
+		if (expandedPolyfillNames.length === 0) {
+			return undefined;
+		}
+
+		if (polyfillIdentifierName in sources) {
+			expandedPolyfillNames.push(polyfillIdentifierName);
+		}
+
+		return expandedPolyfillNames;
+	});
+}());
 
 function getPolyfillString(options) {
 	var ua = getUserAgentInfo(options.uaString),

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,15 +75,16 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 	});
 });
 
-// Set up AliasResolvers: Each function is applied to a polyfill name, the
-// function should then return an array of new strings that represent the name
-// or undefined to indicate that the name can not be expanded
 (function initAliasResolvers() {
 
-	AliasResolver.addResolver(function (polyfillIdentifierName) {
+	// Each alias resolver function is applied to a polyfill name (string), the
+	// function should then return an array of new strings that represent the name
+	// or undefined to indicate that the name can not be expanded, each is
+	// called in the sequence defined here
+	AliasResolver.addResolver(function aliasFromConfig(polyfillIdentifierName) {
 		// If an name can not be resolved to anything return undefined
 		return configuredAliases[polyfillIdentifierName] || undefined;
-	}).addResolver(function(polyfillIdentifierName) {
+	}).addResolver(function expandNamespacedPolyfills(polyfillIdentifierName) {
 		// Expand a polyfill name i.e. Element.prototype becomes Element.prototype.* etc
 
 		// Append a dot separator to the polyfill name before testing 'startsWith' if it does not already end with a dot.

--- a/polyfills/Element.prototype.matches/config.json
+++ b/polyfills/Element.prototype.matches/config.json
@@ -1,6 +1,6 @@
 {
 	"browsers": {
-		"ie": "6 - 8",
+		"ie": "6 - 8"
 	},
 	"aliases": [
 		"caniuse:matchesselector"

--- a/polyfills/Element.prototype.matches/config.json
+++ b/polyfills/Element.prototype.matches/config.json
@@ -1,17 +1,6 @@
 {
 	"browsers": {
-		"ie": "6 - *",
-		"firefox": "*",
-		"opera": "11.5 - 12.1",
-		"op_mini": "*",
-		"op_mob": "*",
-		"android": "*",
-		"bb": "*",
-		"chrome": "1 - 33",
-		"ios_chr": "*",
-		"opera": "15",
-		"safari": "4 - *",
-		"ios_saf": "*"
+		"ie": "6 - 8",
 	},
 	"aliases": [
 		"caniuse:matchesselector"

--- a/polyfills/Element.prototype.matches/polyfill.js
+++ b/polyfills/Element.prototype.matches/polyfill.js
@@ -1,11 +1,5 @@
 // Element.prototype.matches, Element.prototype.matchesSelector
-Element.prototype.matches = (Element.prototype.matches ||
-				Element.prototype.matchesSelector ||
-				Element.prototype.webkitMatchesSelector ||
-				Element.prototype.msMatchesSelector ||
-				Element.prototype.mozMatchesSelector ||
-				Element.prototype.oMatchesSelector ||
-function matches(selector) {
+Element.prototype.matches = function matches(selector) {
 	var
 	element = this,
 	elements = (element.document || element.ownerDocument).querySelectorAll(selector),
@@ -16,4 +10,4 @@ function matches(selector) {
 	}
 
 	return elements[index] ? true : false;
-});
+};


### PR DESCRIPTION
This pull request allows polyfills to be aliased/expanded based on their own name.

e.g:  `Element.proto` would be expanded to all polyfills that match `Element.proto.*`

This also reverts a temporary fix that this PR solves and fixes a bug in the aliasing which now prevents aliases being created when the name of the polyfill is the same as the alias.

Closes #59 and #57
