### PR TITLE
Support source maps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 var fs = require('fs'),
 	path = require('path'),
-	uglify    = require('uglify-js'),
 	tsort     = require('tsort'),
 	AliasResolver = require('./aliases'),
 	getUserAgentInfo = require('./agent');
@@ -36,7 +35,6 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 		fileContents = fs.readFileSync(polyfillSourcePath, 'utf8'),
 		polyfillInfo = {
 			file: fileContents,
-			minifile: uglify.minify(fileContents, {fromString: true}).code,
 			config: config
 		};
 
@@ -56,7 +54,6 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 		}
 
 		polyfillInfo.gatedFile = gatedFile;
-		polyfillInfo.miniGatedFile = uglify.minify(gatedFile, {fromString: true}).code;
 	}
 
 	sources[polyfillName] = polyfillInfo;
@@ -157,25 +154,14 @@ function getPolyfillString(options) {
 			}
 		}
 
-		var shouldGate = polyfill.flags.indexOf('gated') !== -1;
+		var shouldGate = (polyfill.flags.indexOf('gated') !== -1 && polyfillSource.gatedFile);
+		currentPolyfills[polyfill.name] = (shouldGate) ? polyfillSource.gatedFile : polyfillSource.file;
 
-		var file = polyfillSource.file;
-		var minifile = polyfillSource.minifile;
-
-		if (shouldGate && polyfillSource.gatedFile) {
-			file = polyfillSource.gatedFile;
-			minifile = polyfillSource.miniGatedFile;
-		}
-
-		if (!options.minify) {
-			explainerComment.push(
-				'- ' + polyfill.name +
-				', License: ' + (polyfillConfig.license || 'CC0')  + ' ' +
-				((polyfill.aliasOf && polyfill.aliasOf.length) ? ' (' + polyfill.aliasOf.join(',') + ')' : '')
-			);
-		}
-
-		currentPolyfills[polyfill.name] = options.minify ? minifile : file;
+		explainerComment.push(
+			'- ' + polyfill.name +
+			', License: ' + (polyfillConfig.license || 'CC0')  + ' ' +
+			((polyfill.aliasOf && polyfill.aliasOf.length) ? ' (' + polyfill.aliasOf.join(',') + ')' : '')
+		);
 	});
 
 	var graph = tsort();
@@ -197,7 +183,18 @@ function getPolyfillString(options) {
 		return currentPolyfills[name];
 	}).join('');
 
-	return builtExplainerComment + builtPolyfillString;
+	var output = builtExplainerComment + builtPolyfillString;
+
+	if (options.minify) {
+		var uglres = require('uglify-js').minify(output, {fromString:true, outSourceMap:options.mapUrl});
+		if (options.minify == 'map') {
+			return uglres.map;
+		} else {
+			return uglres.code;
+		}
+	} else {
+		return output;
+	}
 }
 
 module.exports = {

--- a/service/index.js
+++ b/service/index.js
@@ -113,12 +113,11 @@ app.use('/assets', express.static(__dirname + '/../docs/assets'));
 /* API endpoints */
 
 
-app.get(/^\/v1\/polyfill(\.\w+)(\.\w+)?/, function(req, res) {
+app.get(/^\/v1\/polyfill(?:\.(min|map))?(\.\w+)/, function(req, res) {
 	var responseStartTime = Date.now();
 
-	var firstParameter = req.params[0].toLowerCase(),
-		minified =  firstParameter === '.min',
-		fileExtension = minified ? req.params[1].toLowerCase() : firstParameter,
+	var minify = req.params[0],
+		fileExtension = req.params[1].toLowerCase(),
 		isGateForced = req.query.gated === "1",
 		polyfills   = helpers.parseRequestedPolyfills(req.query.features || '', isGateForced ? ["gated"] : []),
 		uaString = req.query.ua || req.header('user-agent');
@@ -126,9 +125,9 @@ app.get(/^\/v1\/polyfill(\.\w+)(\.\w+)?/, function(req, res) {
 	var polyfill = polyfillio.getPolyfills({
 		polyfills: polyfills,
 		extension: fileExtension,
-		minify: minified,
+		minify: minify,
 		uaString: uaString,
-		url: req.originalUrl
+		mapUrl: req.originalUrl.replace(/^\/v1\/polyfill\.min/, '/v1/polyfill.map')
 	});
 
 	if (fileExtension === '.js') {


### PR DESCRIPTION
I made a start on this but ran into problems very quickly because we precompile the minified versions of the polyfills and then just concatenate them when we receive a request.  You can't have multiple source maps per compiled file so we would need to run the minification on request rather than in advance.

I think it's worth considering doing this, because source maps are probably important to developers.
