### PR TITLE
fix for safari5: use window instead of Window

### DIFF
--- a/polyfills/Window.prototype.CustomEvent/polyfill.js
+++ b/polyfills/Window.prototype.CustomEvent/polyfill.js
@@ -1,5 +1,5 @@
 // Window.prototype.CustomEvent
-window.CustomEvent = Window.prototype.CustomEvent = function CustomEvent(type, eventInitDict) {
+window.CustomEvent = window.prototype.CustomEvent = function CustomEvent(type, eventInitDict) {
 	var event = new Event(type, eventInitDict);
 
 	event.detail = eventInitDict && eventInitDict.detail || {};

--- a/polyfills/Window.prototype.XMLHttpRequest.ie7/polyfill.js
+++ b/polyfills/Window.prototype.XMLHttpRequest.ie7/polyfill.js
@@ -1,4 +1,4 @@
 // Window.prototype.XMLHttpRequest
-Window.prototype.XMLHttpRequest = function XMLHttpRequest() {
+window.prototype.XMLHttpRequest = function XMLHttpRequest() {
 	return new ActiveXObject('MSXML2.XMLHTTP.3.0');
 };

--- a/polyfills/Window.prototype.devicePixelRatio.ie8/polyfill.js
+++ b/polyfills/Window.prototype.devicePixelRatio.ie8/polyfill.js
@@ -1,5 +1,5 @@
 // Window.prototype.devicePixelRatio
-Object.defineProperty(Window.prototype, 'devicePixelRatio', {
+Object.defineProperty(window.prototype, 'devicePixelRatio', {
 	get: function () {
 		return screen.deviceXDPI / screen.logicalXDPI;
 	}

--- a/polyfills/Window.prototype.matchMedia/polyfill.js
+++ b/polyfills/Window.prototype.matchMedia/polyfill.js
@@ -53,7 +53,7 @@
 		this.addListener.listeners.splice(this.addListener.listeners.indexof(listener), 1);
 	};
 
-	window.matchMedia = Window.prototype.matchMedia = function matchMedia(query) {
+	window.matchMedia = window.prototype.matchMedia = function matchMedia(query) {
 		var
 		window = this,
 		list = new MediaQueryList();

--- a/polyfills/Window.prototype.scroll/polyfill.js
+++ b/polyfills/Window.prototype.scroll/polyfill.js
@@ -1,5 +1,5 @@
 // Window.prototype.scroll
-Object.defineProperties(Window.prototype, {
+Object.defineProperties(window.prototype, {
 	'scrollX': {
 		get: function () {
 			return this.pageXOffset;


### PR DESCRIPTION
Using "Window" with a capital W triggers an error in safari 5 (maybe others, I haven't tested). The error being "ReferenceError: Can't find variable: Window"
