### PR TITLE
added strict express routing to fix infinite redirect loop

### DIFF
--- a/service/index.js
+++ b/service/index.js
@@ -1,6 +1,6 @@
 var polyfillio = require('../lib'),
 	express = require('express'),
-	app = express(),
+	app = express().enable("strict routing"),
 	packagejson = require('../package.json'),
 	origamijson = require('../origami.json'),
 	helpers = require('./helpers'),


### PR DESCRIPTION
The current behavior of express routes leads to infinite redirect loop when requesting "/v1/", as the trailing "/" is not required when matching the redirect rule.

This can be fixed either by switching to strict routing (as this patch does) or by making the routes more explicit (defining them as RegExps).
