### PR TITLE
Add alias for default polyfill set

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -88,7 +88,7 @@
                             <dt><code>|gated</code></dt>
                             <dd>If the polyfill is included in the bundle, it will be accompanied by a feature detect, which will only execute the polyfill if the native API is not present.</dd>
                         </dl>
-                        <p>If not specified, all polyfills will be considered.</p>
+                        <p>Omitting or setting to an empty string is equivalent to the value "default", which is an alias for a curated list of the most popular polyfills.</p>
                     </td>
                 </tr><tr>
                     <td><code>gated</code></td>
@@ -104,7 +104,7 @@
 
             <h2>Examples</h2>
 
-            <p>Consider all polyfills, bundle and return those which are required by the current browser:</p>
+            <p>Consider default polyfills, bundle and return those which are required by the current browser:</p>
 
             <?prettify?>
             <pre><code>&lt;script src="//cdn.polyfill.io/v1/polyfill.js"&gt;&lt;/script&gt;</code></pre>
@@ -118,12 +118,12 @@
 
             <div class='demo' data-src='/v1/polyfill.js?features=Array.prototype.map,modernizr:es5array|always'></div>
 
-            <p>Consider all polyfills but for an IE7 user-agent:</p>
+            <p>Consider default polyfills, plus Array.from, but for an IE7 user-agent:</p>
 
             <?prettify?>
-            <pre><code>&lt;script src="//cdn.polyfill.io/v1/polyfill.min.js?ua=Mozilla%2F5.0%20(Windows%3B%20U%3B%20MSIE%207.0%3B%20Windows%20NT%206.0%3B%20en-US)"&gt;&lt;/script&gt;</code></pre>
+            <pre><code>&lt;script src="//cdn.polyfill.io/v1/polyfill.min.js?features=default,Array.from&amp;ua=Mozilla%2F5.0%20(Windows%3B%20U%3B%20MSIE%207.0%3B%20Windows%20NT%206.0%3B%20en-US)"&gt;&lt;/script&gt;</code></pre>
 
-            <div class='demo' data-src='/v1/polyfill.min.js?ua=Mozilla%2F5.0%20(Windows%3B%20U%3B%20MSIE%207.0%3B%20Windows%20NT%206.0%3B%20en-US)'></div>
+            <div class='demo' data-src='/v1/polyfill.min.js?features=default,Array.from&amp;ua=Mozilla%2F5.0%20(Windows%3B%20U%3B%20MSIE%207.0%3B%20Windows%20NT%206.0%3B%20en-US)'></div>
 
             <h2>About</h2>
 

--- a/polyfills/Array.isArray/config.json
+++ b/polyfills/Array.isArray/config.json
@@ -5,6 +5,7 @@
 		"safari": "4"
 	},
 	"aliases": [
-		"modernizr:es5array"
+		"modernizr:es5array",
+		"default"
 	]
 }

--- a/polyfills/Array.prototype.every/config.json
+++ b/polyfills/Array.prototype.every/config.json
@@ -3,6 +3,7 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"modernizr:es5array"
+		"modernizr:es5array",
+		"default"
 	]
 }

--- a/polyfills/Array.prototype.filter/config.json
+++ b/polyfills/Array.prototype.filter/config.json
@@ -3,6 +3,7 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"modernizr:es5array"
+		"modernizr:es5array",
+		"default"
 	]
 }

--- a/polyfills/Array.prototype.forEach/config.json
+++ b/polyfills/Array.prototype.forEach/config.json
@@ -3,6 +3,7 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"modernizr:es5array"
+		"modernizr:es5array",
+		"default"
 	]
 }

--- a/polyfills/Array.prototype.indexOf/config.json
+++ b/polyfills/Array.prototype.indexOf/config.json
@@ -3,6 +3,7 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"modernizr:es5array"
+		"modernizr:es5array",
+		"default"
 	]
 }

--- a/polyfills/Array.prototype.lastIndexOf/config.json
+++ b/polyfills/Array.prototype.lastIndexOf/config.json
@@ -3,6 +3,7 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"modernizr:es5array"
+		"modernizr:es5array",
+		"default"
 	]
 }

--- a/polyfills/Array.prototype.map/config.json
+++ b/polyfills/Array.prototype.map/config.json
@@ -3,6 +3,7 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"modernizr:es5array"
+		"modernizr:es5array",
+		"default"
 	]
 }

--- a/polyfills/Array.prototype.reduce/config.json
+++ b/polyfills/Array.prototype.reduce/config.json
@@ -3,6 +3,7 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"modernizr:es5array"
+		"modernizr:es5array",
+		"default"
 	]
 }

--- a/polyfills/Array.prototype.some/config.json
+++ b/polyfills/Array.prototype.some/config.json
@@ -3,6 +3,7 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"modernizr:es5array"
+		"modernizr:es5array",
+		"default"
 	]
 }

--- a/polyfills/Date.now/config.json
+++ b/polyfills/Date.now/config.json
@@ -3,6 +3,7 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"modernizr:es5date"
+		"modernizr:es5date",
+		"default"
 	]
 }

--- a/polyfills/Date.prototype.toISOString/config.json
+++ b/polyfills/Date.prototype.toISOString/config.json
@@ -3,6 +3,7 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"modernizr:es5date"
+		"modernizr:es5date",
+		"default"
 	]
 }

--- a/polyfills/Element.prototype.classList.ie7/config.json
+++ b/polyfills/Element.prototype.classList.ie7/config.json
@@ -4,6 +4,7 @@
 	},
 	"dependencies": ["Window.polyfill.ie7", "Window.prototype.DOMTokenList"],
 	"aliases": [
-		"modernizr:classlist"
+		"modernizr:classlist",
+		"default"
 	]
 }

--- a/polyfills/Element.prototype.classList/config.json
+++ b/polyfills/Element.prototype.classList/config.json
@@ -5,6 +5,7 @@
 	},
 	"dependencies": ["Window.polyfill.ie7", "Object.defineProperties", "Window.prototype.DOMTokenList"],
 	"aliases": [
-		"modernizr:classlist"
+		"modernizr:classlist",
+		"default"
 	]
 }

--- a/polyfills/Element.prototype.matches.moz/config.json
+++ b/polyfills/Element.prototype.matches.moz/config.json
@@ -3,6 +3,7 @@
 		"firefox": "*"
 	},
 	"aliases": [
-		"caniuse:matchesselector"
+		"caniuse:matchesselector",
+		"default"
 	]
 }

--- a/polyfills/Element.prototype.matches.ms/config.json
+++ b/polyfills/Element.prototype.matches.ms/config.json
@@ -3,6 +3,7 @@
 		"ie": "9 - *"
 	},
 	"aliases": [
-		"caniuse:matchesselector"
+		"caniuse:matchesselector",
+		"default"
 	]
 }

--- a/polyfills/Element.prototype.matches.o/config.json
+++ b/polyfills/Element.prototype.matches.o/config.json
@@ -5,6 +5,7 @@
 		"op_mob": "*"
 	},
 	"aliases": [
-		"caniuse:matchesselector"
+		"caniuse:matchesselector",
+		"default"
 	]
 }

--- a/polyfills/Element.prototype.matches.webkit/config.json
+++ b/polyfills/Element.prototype.matches.webkit/config.json
@@ -9,6 +9,7 @@
 		"ios_saf": "*"
 	},
 	"aliases": [
-		"caniuse:matchesselector"
+		"caniuse:matchesselector",
+		"default"
 	]
 }

--- a/polyfills/Element.prototype.matches/config.json
+++ b/polyfills/Element.prototype.matches/config.json
@@ -3,7 +3,8 @@
 		"ie": "6 - 8"
 	},
 	"aliases": [
-		"caniuse:matchesselector"
+		"caniuse:matchesselector",
+		"default"
 	],
 	"dependencies": ["Window.polyfill.ie7"]
 }

--- a/polyfills/Function.prototype.bind/config.json
+++ b/polyfills/Function.prototype.bind/config.json
@@ -5,6 +5,7 @@
 		"safari": "4 - 5.1"
 	},
 	"aliases": [
-		"modernizr:es5function"
+		"modernizr:es5function",
+		"default"
 	]
 }

--- a/polyfills/String.prototype.contains/config.json
+++ b/polyfills/String.prototype.contains/config.json
@@ -10,6 +10,7 @@
 		"ios_saf": "*"
 	},
 	"aliases": [
-		"modernizr:es6string"
+		"modernizr:es6string",
+		"default"
 	]
 }

--- a/polyfills/String.prototype.trim/config.json
+++ b/polyfills/String.prototype.trim/config.json
@@ -4,6 +4,7 @@
 		"safari": "4"
 	},
 	"aliases": [
-		"modernizr:es5string"
+		"modernizr:es5string",
+		"default"
 	]
 }

--- a/polyfills/Window.prototype.JSON/config.json
+++ b/polyfills/Window.prototype.JSON/config.json
@@ -4,7 +4,8 @@
 	},
 	"aliases": [
 		"modernizr:json",
-		"caniuse:json"
+		"caniuse:json",
+		"default"
 	],
 	"license": "MIT Asen Bozhilov JSON.parse (https://github.com/abozhilov/json)",
 	"dependencies": ["Window.polyfill.ie7"]

--- a/polyfills/requestAnimationFrame.moz/config.json
+++ b/polyfills/requestAnimationFrame.moz/config.json
@@ -4,6 +4,7 @@
 	},
 	"aliases": [
 		"modernizr:requestanimationframe",
-		"caniuse:requestanimationframe"
+		"caniuse:requestanimationframe",
+		"default"
 	]
 }

--- a/polyfills/requestAnimationFrame.webkit/config.json
+++ b/polyfills/requestAnimationFrame.webkit/config.json
@@ -5,6 +5,7 @@
 	},
 	"aliases": [
 		"modernizr:requestanimationframe",
-		"caniuse:requestanimationframe"
+		"caniuse:requestanimationframe",
+		"default"
 	]
 }

--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -12,7 +12,8 @@
 	},
 	"aliases": [
 		"modernizr:requestanimationframe",
-		"caniuse:requestanimationframe"
+		"caniuse:requestanimationframe",
+		"default"
 	],
 	"license": "requestAnimationFrame polyfill by Erik Möller, fixes from Paul Irish, Tino Zijdel, and Jonathan Neal"
 }

--- a/service/index.js
+++ b/service/index.js
@@ -135,7 +135,7 @@ app.get(/^\/v1\/polyfill(\.\w+)(\.\w+)?/, function(req, res) {
 		minified =  firstParameter === '.min',
 		fileExtension = minified ? req.params[1].toLowerCase() : firstParameter,
 		isGateForced = req.query.gated === "1",
-		polyfills = PolyfillSet.fromQueryParam(req.query.features || '', isGateForced ? ["gated"] : []),
+		polyfills = PolyfillSet.fromQueryParam(req.query.features || 'default', isGateForced ? ["gated"] : []),
 		uaString = req.query.ua || req.header('user-agent');
 
 	if (!req.query.ua) res.set('Vary', 'User-Agent');


### PR DESCRIPTION
Change the default behaviour to only include certain nominated polyfills.  This breaks backwards compatibility, but from looking at log data all current users of the service are specifying features in a `features` parameter.  And there aren't many users yet.
