### PR TITLE
Apply a minimum baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ All polyfills are located in the polyfills directory, with one subdirectory per 
 
 The config.json file may contain any of the following keys:
 
-* `browsers`: Object, one key per browser family name (see [browser names](#browser-names)), with the value forming either a range or a list of specific versions separated by double pipes, idenitfying the versions to which the polyfill *should be applied*. See [node-semver ranges](https://github.com/npm/node-semver#ranges).
+* `browsers`: Object, one key per browser family name (see [browsers](#browsers) for details), with the value forming either a range or a list of specific versions separated by double pipes, idenitfying the versions to which the polyfill *should be applied*. See [node-semver ranges](https://github.com/npm/node-semver#ranges).  This range is subject to our [baseline support](#browsers).
 * `aliases`: Array, a list of alternate names for referencing the polyfill.  In the example Modernizr names are explicitly namespaced.
 * `dependencies`: Array, a list of canonical polyfill names for polyfills that must be included prior to this one.
 * `author`: Object, metadata about the author of the polyfill, following [NPM convention](https://www.npmjs.org/doc/json.html#people-fields-author-contributors)
@@ -108,22 +108,24 @@ Example:
 
 A request from IE7 would receive this polyfill, since it is targeted to IE 6-9.  It *may* also receive polyfills for `Object.defineProperties` and `Object.create`, since those are dependencies of the polyfill in this example, if those polyfills also apply in IE7.
 
-### Browser names
 
-The short names should be used in the `config.json` to configure the browser
-support using the `browsers` key.
+### Browsers
 
-| Short name | User Agent Name          |
-|:----------:|:-------------------------|
-| `ie`       | Internet Explorer        |
-| `ie_mob`   | Internet Explorer Mobile |
-| `chrome`   | Chrome                   |
-| `ios_chr`  | Chrome on iOS            |
-| `safari`   | Safari                   |
-| `ios_saf`  | Safari on iOS            |
-| `firefox`  | Firefox                  |
-| `android`  | Android Browser          |
-| `opera`    | Opera                    |
-| `op_mob`   | Opera Mobile             |
-| `op_mini`  | Opera Mini               |
-| `bb`       | Blackberry               |
+The short names should be used in the `config.json` to configure the browser support using the `browsers` key.  All browsers are subject to a minimum version to be considered 'worth polyfilling'.  If a request for polyfills is received from an unidentifiable user-agent or one that is older than the minimum supported version, the polyfill bundle will be empty.
+
+
+| Short name | User Agent Name          | Min supported version |
+|:----------:|:-------------------------|:----------------------|
+| `ie`       | Internet Explorer        | 6                     |
+| `ie_mob`   | Internet Explorer Mobile | 8                     |
+| `chrome`   | Chrome                   | 1                     |
+| `safari`   | Safari                   | 3                     |
+| `ios_saf`  | Safari on iOS            | 3                     |
+| `firefox`  | Firefox                  | 3.6                   |
+| `android`  | Android Browser          | 2.3                   |
+| `opera`    | Opera                    | 11                    |
+| `op_mob`   | Opera Mobile             | 10                    |
+| `op_mini`  | Opera Mini               | 5                     |
+| `bb`       | Blackberry               | 6                     |
+
+The minimum supported version is intentionally lower than most developers will need, because *it cannot be safely lowered*.  We raise the minimum when testing on a particular browser becomes inconveniently hard.

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -54,17 +54,17 @@ var agentmappings = {
 };
 
 var baseLineVersions = {
-	"ie": 6,
-	"ie_mob": 8,
-	"chrome": 1,
-	"safari": 3,
-	"ios_saf": 3,
-	"firefox": 3.6,
-	"android": 2.3,
-	"opera": 11,
-	"op_mob": 10,
-	"op_mini": 5,
-	"bb": 6
+	"ie": ">=6",
+	"ie_mob": ">=8",
+	"chrome": "*",
+	"safari": ">=3",
+	"ios_saf": ">=3",
+	"firefox": ">=3.6",
+	"android": ">=2.3",
+	"opera": ">=11",
+	"op_mob": ">=10",
+	"op_mini": ">=5",
+	"bb": ">=6"
 }
 
 // Invert the mappings above mapping each user agent to the caniuse name for
@@ -113,7 +113,17 @@ UA.prototype.getVersion = function() {
 }
 
 UA.prototype.satisfies = function() {
-	return this.ua.satisfies.apply(this.ua, arguments) && (this.ua.family in baseLineVersions && baseLineVersions[this.ua.family] <= this.ua.toVersion());
+	return (
+		this.ua.satisfies.apply(this.ua, arguments) &&
+		this.ua.family in baseLineVersions &&
+		this.ua.satisfies(baseLineVersions[this.ua.family])
+	);
+}
+UA.prototype.getBaseline = function() {
+	return baseLineVersions[this.ua.family];
+}
+UA.prototype.meetsBaseline = function() {
+	return (this.ua.satisfies(baseLineVersions[this.ua.family]));
 }
 
 UA.normalize = function(uaString) {

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -53,6 +53,20 @@ var agentmappings = {
 	]
 };
 
+var baseLineVersions = {
+	"ie": 6,
+	"ie_mob": 8,
+	"chrome": 1,
+	"safari": 3,
+	"ios_saf": 3,
+	"firefox": 3.6,
+	"android": 2.3,
+	"opera": 11,
+	"op_mob": 10,
+	"op_mini": 5,
+	"bb": 6
+}
+
 // Invert the mappings above mapping each user agent to the caniuse name for
 // faster lookup in agent list
 var agentlist = {};
@@ -99,7 +113,7 @@ UA.prototype.getVersion = function() {
 }
 
 UA.prototype.satisfies = function() {
-	return this.ua.satisfies.apply(this.ua, arguments);
+	return this.ua.satisfies.apply(this.ua, arguments) && (this.ua.family in baseLineVersions && baseLineVersions[this.ua.family] <= this.ua.toVersion());
 }
 
 UA.normalize = function(uaString) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -117,31 +117,31 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 
 function getPolyfillString(options) {
 	var ua = new UA(options.uaString),
-		explainerComment = options.minify ? [
-			'Rerun without minification for verbose metadata'
-		] : [
-			'Polyfill bundle includes the following polyfills.  For detailed credits',
-			'and licence information see http://github.com/financial-times/polyfill-service.',
-			'',
-			'Detected: ' + ua.getFamily() + '/' + ua.getVersion(),
-			''
-		],
-		currentPolyfills = {};
-
-
-	var desired = options.polyfills
-
-	// By default conditionally include all polyfills based on the User Agent
-	if (desired.length === 0) {
-		desired = Object.keys(sources).map(function(name) {
-			return {
-				flags: [],
-				name: name
-			}
-		})
+		desired = options.polyfills,
+		currentPolyfills = {},
+		explainerComment
+	;
+	if (ua.meetsBaseline()) {
+		if (options.minify) {
+			explainerComment = ['Rerun without minification for verbose metadata'];
+		} else  {
+			explainerComment = [
+				'Polyfill bundle includes the following polyfills.  For detailed credits',
+				'and licence information see http://github.com/financial-times/polyfill-service.',
+				'',
+				'Detected: ' + ua.getFamily() + '/' + ua.getVersion(),
+				''
+			]
+		}
 	} else {
-		desired = AliasResolver.resolvePolyfills(desired);
+		explainerComment = ['Unsupported UA detected: ' + ua.getFamily() + '/' + ua.getVersion()];
+		if (ua.getBaseline()) {
+			explainerComment.push('Version range for polyfill support in this family is: ' + ua.getBaseline());
+		}
+		desired = [];
 	}
+
+	desired = AliasResolver.resolvePolyfills(desired);
 
 	desired.forEach(function(polyfill) {
 		var polyfillSource = sources[polyfill.name];
@@ -206,7 +206,7 @@ function getPolyfillString(options) {
 		return currentPolyfills[name];
 	}).join('');
 
-	return '/* ' + explainerComment.join('\n * ') + '\n */\n\n' + builtPolyfillString;
+	return '/* ' + explainerComment.join('\n * ') + ' */\n\n' + builtPolyfillString;
 }
 
 module.exports = {

--- a/service/index.js
+++ b/service/index.js
@@ -7,7 +7,8 @@ var polyfillio = require('../lib'),
 	path = require('path'),
 	parseArgs = require('minimist'),
 	ServiceMetrics = require('./metrics'),
-	appVersion = require('fs').readFileSync('./.semver', {encoding:'UTF-8'}).replace(/\s+$/, '');
+	fs = require('fs'),
+	appVersion = fs.existsSync('./.semver') ? fs.readFileSync('./.semver', {encoding:'UTF-8'}).replace(/\s+$/, '') : 'Unknown';
 
 'use strict';
 


### PR DESCRIPTION
Note: as part of this, I've removed the behaviour that automatically adds all polyfills if you request none, which was added by @bockit.  However, with the introduction of the default alias, I don't think we need that behaviour anymore, and setting an empty list of polyfills is useful for browsers below the baseline.
