### PR TITLE
Update API and add method for getting a list of unaliased polyfills based on their configured browser ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Returns a bundle of polyfills as a string.  Options is an object with the follow
 * `uaString`: String, required. The user agent to evaluate for polyfills that should be included conditionally
 * `minify`: Boolean, optional. Whether to minify the bundle
 * `type`: String, optional. 'js' or 'css', defaults to js
-* `polyfills`: Array, optional.  The list of polyfills that are to be considered for inclusion.  If not supplied, all polyfills will be considered.  Each polyfill must be in the form of an object with the following properties:
-	* `name`: String, required. Name of polyfill, matching a folder name in the polyfills directory, or a known alias
-	* `flags`: Array, optional. Array of flags to apply to this polyfill (see below)
+* `features`: Array, optional.  The list of features that are to be considered for polyfill inclusion.  If not supplied, all default features will be considered.  Each feature must be in the form of an object with the following properties:
+	* `name`: String, required. Name of features, matching a folder name in the polyfills directory, or a known alias
+	* `flags`: Array, optional. Array of flags to apply to this feature (see below)
 
 Flags that may be applied to polyfills are:
 
@@ -53,29 +53,29 @@ Example:
 require('polyfill-service').getPolyfillString({
 	uaString: "Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; en-US)",
 	minify: true,
-	polyfills: [
+	features: [
 		{name:"Element.prototype.matches", flags:['always', 'gated']},
 		{name:"modernizr:es5array"}
 	]
 }));
 ```
 
-#### `getPolyfills(uaString, desiredPolyfills)` (method)
+#### `getPolyfills(options)` (method)
 
-Returns a list of polyfills whose configuration matches the given user agent string.
+Returns a list of features whose configuration matches the given user agent string.
 Options is an object with the following keys:
 
-* `uaString`: String, required. The user agent to evaluate for polyfills that should be included conditionally
-* `polyfills`: Array, required. The list of polyfills that are to be considered for inclusion. Each polyfill must be in the form of an object with the following properties:
-	* `name`: String, required. Name of polyfill, matching a folder name in the polyfills directory, or a known alias
-	* `flags`: Array, optional. Array of flags to apply to this polyfill (see below)
+* `uaString`: String, required. The user agent to evaluate for features that should be included conditionally
+* `features`: Array, optional.  The list of features that are to be considered for polyfill inclusion.  If not supplied, all default features will be considered.  Each feature must be in the form of an object with the following properties:
+	* `name`: String, required. Name of features, matching a folder name in the polyfills directory, or a known alias
+	* `flags`: Array, optional. Array of flags to apply to this feature (see above in `getPolyfillString`)
 
 Example:
 
 ```javascript
 require('polyfill-service').getPolyfills({
 	uaString: "Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; en-US)",
-	polyfills: [
+	features: [
 		{name:"Element.prototype.matches", flags:['always', 'gated']},
 		{name:"modernizr:es5array"}
 	]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Polyfill service can also be used as a library in NodeJS projects.  To do this:
 
 ### Library API reference
 
-#### `getPolyfills(options)` (method)
+#### `getPolyfillString(options)` (method)
 
 Returns a bundle of polyfills as a string.  Options is an object with the following keys:
 
@@ -50,7 +50,7 @@ Flags that may be applied to polyfills are:
 Example:
 
 ```javascript
-require('polyfill-service').getPolyfills({
+require('polyfill-service').getPolyfillString({
 	uaString: "Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; en-US)",
 	minify: true,
 	polyfills: [
@@ -58,6 +58,28 @@ require('polyfill-service').getPolyfills({
 		{name:"modernizr:es5array"}
 	]
 }));
+```
+
+#### `getPolyfills(uaString, desiredPolyfills)` (method)
+
+Returns a list of polyfills whose configuration matches the given user agent string.
+Options is an object with the following keys:
+
+* `uaString`: String, required. The user agent to evaluate for polyfills that should be included conditionally
+* `polyfills`: Array, required. The list of polyfills that are to be considered for inclusion. Each polyfill must be in the form of an object with the following properties:
+	* `name`: String, required. Name of polyfill, matching a folder name in the polyfills directory, or a known alias
+	* `flags`: Array, optional. Array of flags to apply to this polyfill (see below)
+
+Example:
+
+```javascript
+require('polyfill-service').getPolyfills({
+	uaString: "Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; en-US)",
+	polyfills: [
+		{name:"Element.prototype.matches", flags:['always', 'gated']},
+		{name:"modernizr:es5array"}
+	]
+});
 ```
 
 ## Polyfill configuration

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,14 +116,14 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 }());
 
 /**
- * Given a list of desired polyfills in 'options.polyfills' (with flags i.e. `{ name: <polyfillname>, flags: [<flaglist>] }`)
- * Determine which have configuration valid for the given options.uaString
+ * Given a list of features that should be polyfilled in 'options.features' (with flags i.e. `{ name: <featurename>, flags: [<flaglist>] }`)
+ * Determine which have a configuration valid for the given options.uaString
  *
- * @return a list of polyfills (with flags)
+ * @return a list of canonical (unaliased) features (with flags)
  */
 function getPolyfills(options) {
 	var ua = new UA(options.uaString),
-		desired = options.polyfills,
+		desired = options.features,
 		currentPolyfills = {},
 		polyfillList = [];
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,12 +115,56 @@ fs.readdirSync(polyfillSourceFolder).forEach(function (polyfillName) {
 	});
 }());
 
-function getPolyfillString(options) {
+/**
+ * Given a list of desired polyfills in 'options.polyfills' (with flags i.e. `{ name: <polyfillname>, flags: [<flaglist>] }`)
+ * Determine which have configuration valid for the given options.uaString
+ *
+ * @return a list of polyfills (with flags)
+ */
+function getPolyfills(options) {
 	var ua = new UA(options.uaString),
 		desired = options.polyfills,
 		currentPolyfills = {},
-		explainerComment
-	;
+		polyfillList = [];
+
+	if (!ua.meetsBaseline()) {
+		desired = [];
+	}
+
+	desired = AliasResolver.resolvePolyfills(desired);
+
+	desired.forEach(function(polyfill) {
+		var polyfillSource = sources[polyfill.name];
+
+		if (polyfillSource) {
+			var polyfillConfig = polyfillSource.config;
+			var alwaysInclude = polyfill.flags.indexOf('always') !== -1;
+
+			if (!alwaysInclude) {
+				var browsersConfigured = polyfillConfig && polyfillConfig.browsers;
+
+				if (!(browsersConfigured)) {
+					return;
+				}
+
+				var browserVersion = polyfillConfig.browsers[ua.getFamily()];
+				if (!(browserVersion && ua.satisfies(browserVersion))) {
+					return;
+				}
+			}
+		}
+
+		polyfillList.push(polyfill);
+	});
+
+	return polyfillList;
+}
+
+function getPolyfillString(options) {
+	var ua = new UA(options.uaString),
+		currentPolyfills = {},
+		explainerComment;
+
 	if (ua.meetsBaseline()) {
 		if (options.minify) {
 			explainerComment = ['Rerun without minification for verbose metadata'];
@@ -138,10 +182,9 @@ function getPolyfillString(options) {
 		if (ua.getBaseline()) {
 			explainerComment.push('Version range for polyfill support in this family is: ' + ua.getBaseline());
 		}
-		desired = [];
 	}
 
-	desired = AliasResolver.resolvePolyfills(desired);
+	var desired = getPolyfills(options);
 
 	desired.forEach(function(polyfill) {
 		var polyfillSource = sources[polyfill.name];
@@ -152,21 +195,6 @@ function getPolyfillString(options) {
 		}
 
 		var polyfillConfig = polyfillSource.config;
-		var alwaysInclude = polyfill.flags.indexOf('always') !== -1;
-
-		if (!alwaysInclude) {
-			var browsersConfigured = polyfillConfig && polyfillConfig.browsers;
-
-			if (!(browsersConfigured)) {
-				return;
-			}
-
-			var browserVersion = polyfillConfig.browsers[ua.getFamily()];
-			if (!(browserVersion && ua.satisfies(browserVersion))) {
-				return;
-			}
-		}
-
 		var shouldGate = polyfill.flags.indexOf('gated') !== -1;
 
 		var file = polyfillSource.file;
@@ -210,6 +238,7 @@ function getPolyfillString(options) {
 }
 
 module.exports = {
-	getPolyfills: getPolyfillString,
+	getPolyfills: getPolyfills,
+	getPolyfillString: getPolyfillString,
 	normalizeUserAgent: UA.normalize
 };

--- a/service/index.js
+++ b/service/index.js
@@ -150,7 +150,7 @@ app.get(/^\/v1\/polyfill(\.\w+)(\.\w+)?/, function(req, res) {
 		res.set('Content-Type', contentTypes[fileExtension]+';charset=utf-8');
 		res.set('Access-Control-Allow-Origin', '*');
 		res.send(polyfillio.getPolyfillString({
-			polyfills: polyfills.get(),
+			features: polyfills.get(),
 			extension: fileExtension,
 			minify: minified,
 			uaString: uaString,

--- a/service/index.js
+++ b/service/index.js
@@ -149,7 +149,7 @@ app.get(/^\/v1\/polyfill(\.\w+)(\.\w+)?/, function(req, res) {
 	} else {
 		res.set('Content-Type', contentTypes[fileExtension]+';charset=utf-8');
 		res.set('Access-Control-Allow-Origin', '*');
-		res.send(polyfillio.getPolyfills({
+		res.send(polyfillio.getPolyfillString({
 			polyfills: polyfills.get(),
 			extension: fileExtension,
 			minify: minified,


### PR DESCRIPTION
Split out the method for getting a subset of polyfills, from a list of polyfill names (potentially aliased), based on their browser configuration and the supplied UA string
