### PR TITLE
Readsync

### DIFF
--- a/service/docs.js
+++ b/service/docs.js
@@ -13,6 +13,9 @@ var indexTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/index.html
 var usageTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/usage.html'), {encoding: 'UTF-8'}),
 	usageTemplate    = Handlebars.compile(usageTemplateSrc);
 
+var compatTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/compat.html'), {encoding: 'UTF-8'}),
+	compatTemplate = Handlebars.compile(compatTemplateSrc);
+
 Handlebars.registerHelper("prettifyDate", function(timestamp) {
      return Moment(timestamp*1000).format("D MMM YYYY HH:mm");
 });
@@ -170,9 +173,7 @@ function route(req, res, next) {
 			});
 		});
 	} else if (req.params[0] === 'features') {
-		templateSrc = fs.readFileSync(path.join(__dirname, '/../docs/compat.html'), {encoding: 'UTF-8'}),
-		template = Handlebars.compile(templateSrc);
-		res.send(template({
+		res.send(compatTemplate({
 			section: 'features',
 			compat: getCompat()
 		}));

--- a/service/docs.js
+++ b/service/docs.js
@@ -10,6 +10,9 @@ var cache = {fastly:{}, outages:{}, respTimes:{}},
 var indexTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/index.html'), {encoding: 'UTF-8'}),
 	indexTemplate    = Handlebars.compile(indexTemplateSrc);
 
+var usageTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/usage.html'), {encoding: 'UTF-8'}),
+	usageTemplate    = Handlebars.compile(usageTemplateSrc);
+
 Handlebars.registerHelper("prettifyDate", function(timestamp) {
      return Moment(timestamp*1000).format("D MMM YYYY HH:mm");
 });
@@ -155,9 +158,7 @@ function route(req, res, next) {
 		getData('fastly', function(fastlyData) {
 			getData('outages', function(outages) {
 				getData('respTimes', function(respTimes) {
-					templateSrc = fs.readFileSync(path.join(__dirname, '/../docs/usage.html'), {encoding: 'UTF-8'}),
-					template = Handlebars.compile(templateSrc);
-					res.send(template({
+					res.send(usageTemplate({
 						section: 'usage',
 						requestsData: fastlyData.byhour,
 						outages: outages,

--- a/service/docs.js
+++ b/service/docs.js
@@ -14,7 +14,16 @@ var usageTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/usage.html
 	usageTemplate    = Handlebars.compile(usageTemplateSrc);
 
 var compatTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/compat.html'), {encoding: 'UTF-8'}),
-	compatTemplate = Handlebars.compile(compatTemplateSrc);
+	compatTemplate    = Handlebars.compile(compatTemplateSrc);
+
+var apiTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/api.html'), {encoding: 'UTF-8'}),
+	apiTemplate    = Handlebars.compile(apiTemplateSrc);
+
+var examplesTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/examples.html'), {encoding: 'UTF-8'}),
+    examplesTemplate = Handlebars.compile(examplesTemplateSrc);
+
+var contribTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/contributing.html'), {encoding: 'UTF-8'}),
+    contribTemplate = Handlebars.compile(contribTemplateSrc);
 
 Handlebars.registerHelper("prettifyDate", function(timestamp) {
      return Moment(timestamp*1000).format("D MMM YYYY HH:mm");
@@ -178,21 +187,15 @@ function route(req, res, next) {
 			compat: getCompat()
 		}));
 	} else if (req.params[0] === 'api') {
-		templateSrc = fs.readFileSync(path.join(__dirname, '/../docs/api.html'), {encoding: 'UTF-8'}),
-		template = Handlebars.compile(templateSrc);
-		res.send(template({
+		res.send(apiTemplate({
 			section: 'api'
 		}));
 	} else if (req.params[0] === 'examples') {
-		templateSrc = fs.readFileSync(path.join(__dirname, '/../docs/examples.html'), {encoding: 'UTF-8'}),
-		template = Handlebars.compile(templateSrc);
-		res.send(template({
+		res.send(examplesTemplate({
 			section: 'examples'
 		}));
 	} else if (req.params[0] === 'contributing') {
-		templateSrc = fs.readFileSync(path.join(__dirname, '/../docs/contributing.html'), {encoding: 'UTF-8'}),
-		template = Handlebars.compile(templateSrc);
-		res.send(template({
+		res.send(contribTemplate({
 			section: 'contributing',
 			baselines: require('../lib/UA').getBaselines()
 		}));

--- a/service/docs.js
+++ b/service/docs.js
@@ -7,6 +7,9 @@ var fs = require('fs'),
 var cache = {fastly:{}, outages:{}, respTimes:{}},
 	cachettl = 1800;
 
+var indexTemplateSrc = fs.readFileSync(path.join(__dirname, '/../docs/index.html'), {encoding: 'UTF-8'}),
+	indexTemplate    = Handlebars.compile(indexTemplateSrc);
+
 Handlebars.registerHelper("prettifyDate", function(timestamp) {
      return Moment(timestamp*1000).format("D MMM YYYY HH:mm");
 });
@@ -147,9 +150,7 @@ function route(req, res, next) {
 	if (req.path.length < "/v1/docs/".length) return res.redirect('/v1/docs/');
 
 	if (!req.params || !req.params[0]) {
-		templateSrc = fs.readFileSync(path.join(__dirname, '/../docs/index.html'), {encoding: 'UTF-8'}),
-		template = Handlebars.compile(templateSrc);
-		res.send(template({section: 'index'}));
+		res.send(indexTemplate({section: 'index'}));
 	} else if (req.params[0] === 'usage') {
 		getData('fastly', function(fastlyData) {
 			getData('outages', function(outages) {


### PR DESCRIPTION
Move file reads to service startup.  It's probably a bad idea to block the Javascript on the filesystem serving the docs.  This would degrade performance for the polyfill.js endpoint.

This is really the pre-requisite for reducing the cache TTL for the usage endpoint.
