### PR TITLE
Set cache ttl to one hour for the usage endpoint

### DIFF
--- a/service/docs.js
+++ b/service/docs.js
@@ -151,6 +151,11 @@ function route(req, res, next) {
 		template = Handlebars.compile(templateSrc);
 		res.send(template({section: 'index'}));
 	} else if (req.params[0] === 'usage') {
+		// Set the ttl to one hour for the usage page so the graphs are
+		// updated.
+		var one_hour = 60 * 60;
+		var one_week = one_hour * 24 * 7;
+		res.set('Cache-Control', 'public, max-age=' + one_hour +', stale-while-revalidate=' + one_week + ', stale-if-error=' + one_week);
 		getData('fastly', function(fastlyData) {
 			getData('outages', function(outages) {
 				getData('respTimes', function(respTimes) {

--- a/service/docs.js
+++ b/service/docs.js
@@ -152,7 +152,8 @@ function route(req, res, next) {
 		res.send(template({section: 'index'}));
 	} else if (req.params[0] === 'usage') {
 		// Set the ttl to one hour for the usage page so the graphs are
-		// updated.
+		// updated more frequently, overriding the default cache-control
+		// behaviour set in index.js
 		var one_hour = 60 * 60;
 		var one_week = one_hour * 24 * 7;
 		res.set('Cache-Control', 'public, max-age=' + one_hour +', stale-while-revalidate=' + one_week + ', stale-if-error=' + one_week);


### PR DESCRIPTION
This means it should update the stats once per hour :+1: 
