### PR TITLE
Remove unnecessary x-powered-by header.  Save a few bytes!

### DIFF
--- a/service/index.js
+++ b/service/index.js
@@ -28,6 +28,7 @@ var one_year = one_day * 365;
 // Default cache control policy
 app.use(function(req, res, next) {
 	res.set('Cache-Control', 'public, max-age='+one_day+', stale-while-revalidate='+one_week+', stale-if-error='+one_week);
+	res.removeHeader("x-powered-by");
 	return next();
 });
 


### PR DESCRIPTION
Save a few bytes in the response header by not including: `X-Powered-By: Express`
