### PR TITLE
Update Node.prototype.contains

### DIFF
--- a/polyfills/Node.prototype.contains/config.json
+++ b/polyfills/Node.prototype.contains/config.json
@@ -1,0 +1,24 @@
+{
+	"aliases": [
+		"dom4"
+	],
+	"browsers": {
+		"firefox": "* - 8",
+		"safari": "* - 2"
+	},
+	"variants": {
+		"document": {
+			"browsers": {
+				"ie": "* - 8"
+			},
+			"dependencies": [
+				"Element"
+			]
+		},
+		"HTMLElement": {
+			"browsers": {
+				"ie": "9 - *"
+			}
+		}
+	}
+}

--- a/polyfills/Node.prototype.contains/detect.js
+++ b/polyfills/Node.prototype.contains/detect.js
@@ -1,0 +1,1 @@
+document.contains

--- a/polyfills/Node.prototype.contains/polyfill-HTMLElement.js
+++ b/polyfills/Node.prototype.contains/polyfill-HTMLElement.js
@@ -1,0 +1,15 @@
+delete HTMLElement.prototype.contains;
+
+Node.prototype.contains = function contains(node) {
+	if (!(0 in arguments)) {
+		throw new TypeError('1 argument is required');
+	}
+
+	do {
+		if (this === node) {
+			return true;
+		}
+	} while (node = node && node.parentNode);
+
+	return false;
+};

--- a/polyfills/Node.prototype.contains/polyfill-document.js
+++ b/polyfills/Node.prototype.contains/polyfill-document.js
@@ -1,0 +1,13 @@
+document.contains = Element.prototype.contains = function contains(node) {
+	if (!(0 in arguments)) {
+		throw new TypeError('1 argument is required');
+	}
+
+	do {
+		if (this === node) {
+			return true;
+		}
+	} while (node = node && node.parentNode);
+
+	return false;
+};

--- a/polyfills/Node.prototype.contains/polyfill.js
+++ b/polyfills/Node.prototype.contains/polyfill.js
@@ -1,0 +1,13 @@
+Node.prototype.contains = function contains(node) {
+	if (!(0 in arguments)) {
+		throw new TypeError('1 argument is required');
+	}
+
+	do {
+		if (this === node) {
+			return true;
+		}
+	} while (node = node && node.parentNode);
+
+	return false;
+};

--- a/polyfills/Node.prototype.contains/tests.js
+++ b/polyfills/Node.prototype.contains/tests.js
@@ -1,0 +1,66 @@
+describe('on an element', function () {
+	var
+	documentElement = document.documentElement,
+	documentHead = document.getElementsByTagName('head')[0],
+	detached = document.createElement('div');
+
+	it('is a function', function () {
+		expect(documentElement.contains).to.be.a('function');
+	});
+
+	it('expects one argument', function () {
+		expect(documentElement.contains.length).to.be(1);
+	});
+
+	it('functions correctly', function () {
+		expect(documentElement.contains(documentElement)).to.be(true);
+		expect(documentElement.contains(documentHead)).to.be(true);
+
+		expect(documentHead.contains(documentElement)).to.be(false);
+		expect(documentHead.contains(null)).to.be(false);
+	});
+
+	it('functions correctly (on detached elements)', function () {
+		expect(detached.contains(detached)).to.be(true);
+
+		expect(documentElement.contains(detached)).to.be(false);
+		expect(detached.contains(documentElement)).to.be(false);
+		expect(documentHead.contains(null)).to.be(false);
+	});
+
+	it('throws when missing the argument', function () {
+		expect(function () {
+			documentElement.contains();
+		}).to.throwException();
+	});
+});
+
+describe('on the document', function () {
+	var
+	documentElement = document.documentElement,
+	documentHead = document.getElementsByTagName('head')[0],
+	detached = document.createElement('div');
+
+	it('is a function', function () {
+		expect(document.contains).to.be.a('function');
+	});
+
+	it('expects one argument', function () {
+		expect(document.contains.length).to.be(1);
+	});
+
+	it('functions correctly', function () {
+		expect(document.contains(document)).to.be(true);
+		expect(document.contains(documentElement)).to.be(true);
+		expect(document.contains(documentHead)).to.be(true);
+
+		expect(document.contains(detached)).to.be(false);
+		expect(documentElement.contains(document)).to.be(false);
+	});
+
+	it('throws when missing the argument', function () {
+		expect(function () {
+			document.contains();
+		}).to.throwException();
+	});
+});


### PR DESCRIPTION
- add support for various firefox, safari, and IE browsers
- add tests (warning, bad native implementations in old IE crash the
  browser)
- resolve crashing native implementations in old IE
- resolve #177
