### PR TITLE
Updating default set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ source/*/*.min.js
 source/*/*.min.js.map
 test/results
 /dev.sh
+.idea/
+polyfillTestReport.json
+polyfillsizes.json

--- a/polyfills/Array.isArray/config.json
+++ b/polyfills/Array.isArray/config.json
@@ -1,15 +1,15 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"firefox": "3.6",
-		"safari": "4"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	]
+  "aliases": [
+    "es5",
+    "modernizr:es5array",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8",
+    "firefox": "3.6",
+    "safari": "4"
+  },
+  "dependencies": [
+    "Object.defineProperty"
+  ]
 }

--- a/polyfills/Array.prototype.every/config.json
+++ b/polyfills/Array.prototype.every/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5array",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/Array.prototype.filter/config.json
+++ b/polyfills/Array.prototype.filter/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5array",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/Array.prototype.forEach/config.json
+++ b/polyfills/Array.prototype.forEach/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5array",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/Array.prototype.indexOf/config.json
+++ b/polyfills/Array.prototype.indexOf/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5array",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/Array.prototype.lastIndexOf/config.json
+++ b/polyfills/Array.prototype.lastIndexOf/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5array",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/Array.prototype.map/config.json
+++ b/polyfills/Array.prototype.map/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5array",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/Array.prototype.reduce/config.json
+++ b/polyfills/Array.prototype.reduce/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5array",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/Array.prototype.reduceRight/config.json
+++ b/polyfills/Array.prototype.reduceRight/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5array",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/Array.prototype.some/config.json
+++ b/polyfills/Array.prototype.some/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5array"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5array",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/CustomEvent/config.json
+++ b/polyfills/CustomEvent/config.json
@@ -1,26 +1,26 @@
 {
-	"aliases": [
-		"default",
-		"modernizr:customevent"
-	],
-	"browsers": {
-		"firefox": "3.6 - 10",
-		"ie": "9 - *",
-		"opera": "10 - 11.5",
-		"safari": "4 - *",
-		"chrome": "1 - 14"
-	},
-	"dependencies": [
-		"Event"
-	],
-	"variants": {
-		"ie8": {
-			"browsers": {
-				"ie": "6 - 8"
-			},
-			"dependencies": [
-				"Event"
-			]
-		}
-	}
+  "aliases": [
+    "modernizr:customevent",
+    "default"
+  ],
+  "browsers": {
+    "firefox": "3.6 - 10",
+    "ie": "9 - *",
+    "opera": "10 - 11.5",
+    "safari": "4 - *",
+    "chrome": "1 - 14"
+  },
+  "dependencies": [
+    "Event"
+  ],
+  "variants": {
+    "ie8": {
+      "browsers": {
+        "ie": "6 - 8"
+      },
+      "dependencies": [
+        "Event"
+      ]
+    }
+  }
 }

--- a/polyfills/DOMTokenList/config.json
+++ b/polyfills/DOMTokenList/config.json
@@ -1,17 +1,17 @@
 {
-	"aliases": [
-		"default"
-	],
-	"browsers": {
-		"ie": "6 - 9",
-		"safari": "4 - 5.0"
-	},
-	"variants": {
-		"toggle": {
-			"browsers": {
-				"ie": "10 - *",
-				"safari": "5.1 - 6.0"
-			}
-		}
-	}
+  "aliases": [
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 9",
+    "safari": "4 - 5.0"
+  },
+  "variants": {
+    "toggle": {
+      "browsers": {
+        "ie": "10 - *",
+        "safari": "5.1 - 6.0"
+      }
+    }
+  }
 }

--- a/polyfills/Date.now/config.json
+++ b/polyfills/Date.now/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5date"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5date",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/Date.prototype.toISOString/config.json
+++ b/polyfills/Date.prototype.toISOString/config.json
@@ -1,10 +1,10 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5date"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5date",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  }
 }

--- a/polyfills/Document/config.json
+++ b/polyfills/Document/config.json
@@ -1,22 +1,22 @@
 {
-	"aliases": [
-		"default"
-	],
-	"variants": {
-		"ie7": {
-			"browsers": {
-				"ie": "6 - 7"
-			}
-		},
-		"ie8": {
-			"browsers": {
-				"ie": "8"
-			}
-		},
-		"ie9": {
-			"browsers": {
-				"ie": "9"
-			}
-		}
-	}
+  "aliases": [
+    "default"
+  ],
+  "variants": {
+    "ie7": {
+      "browsers": {
+        "ie": "6 - 7"
+      }
+    },
+    "ie8": {
+      "browsers": {
+        "ie": "8"
+      }
+    },
+    "ie9": {
+      "browsers": {
+        "ie": "9"
+      }
+    }
+  }
 }

--- a/polyfills/Element.prototype.classList/config.json
+++ b/polyfills/Element.prototype.classList/config.json
@@ -1,15 +1,15 @@
 {
-	"aliases": [
-		"default",
-		"modernizr:classlist"
-	],
-	"browsers": {
-		"ie": "6 - 9",
-		"safari": "4 - 4.1"
-	},
-	"dependencies": [
-		"Object.defineProperty",
-		"DOMTokenList",
-		"Element"
-	]
+  "aliases": [
+    "modernizr:classlist",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 9",
+    "safari": "4 - 4.1"
+  },
+  "dependencies": [
+    "Object.defineProperty",
+    "DOMTokenList",
+    "Element"
+  ]
 }

--- a/polyfills/Element.prototype.closest/config.json
+++ b/polyfills/Element.prototype.closest/config.json
@@ -1,21 +1,21 @@
 {
-	"aliases": [
-		"default"
-	],
-	"browsers": {
-		"bb": "*",
-		"android": "*",
-		"chrome": "*",
-		"ie": "*",
-		"ie_mob": "*",
-		"ios_saf": "*",
-		"firefox": "*",
-		"opera": "*",
-		"op_mini": "*",
-		"op_mob": "*",
-		"safari": "*"
-	},
-	"dependencies": [
-		"Element.prototype.matches"
-	]
+  "aliases": [
+    "default"
+  ],
+  "browsers": {
+    "bb": "*",
+    "android": "*",
+    "chrome": "*",
+    "ie": "*",
+    "ie_mob": "*",
+    "ios_saf": "*",
+    "firefox": "*",
+    "opera": "*",
+    "op_mini": "*",
+    "op_mob": "*",
+    "safari": "*"
+  },
+  "dependencies": [
+    "Element.prototype.matches"
+  ]
 }

--- a/polyfills/Element.prototype.matches/config.json
+++ b/polyfills/Element.prototype.matches/config.json
@@ -1,44 +1,44 @@
 {
-	"aliases": [
-		"default",
-		"caniuse:matchesselector"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"safari": "4"
-	},
-	"dependencies": [
-		"Element",
-		"document.querySelector"
-	],
-	"variants": {
-		"moz": {
-			"browsers": {
-				"firefox": "*"
-			}
-		},
-		"ms": {
-			"browsers": {
-				"ie": "9 - *"
-			}
-		},
-		"o": {
-			"browsers": {
-				"opera": "11.5 - 12.1",
-				"op_mini": "*",
-				"op_mob": "*"
-			}
-		},
-		"webkit": {
-			"browsers": {
-				"android": "*",
-				"bb": "*",
-				"chrome": "1 - 33",
-				"ios_chr": "*",
-				"opera": "15",
-				"safari": "5 - *",
-				"ios_saf": "*"
-			}
-		}
-	}
+  "aliases": [
+    "caniuse:matchesselector",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8",
+    "safari": "4"
+  },
+  "dependencies": [
+    "Element",
+    "document.querySelector"
+  ],
+  "variants": {
+    "moz": {
+      "browsers": {
+        "firefox": "*"
+      }
+    },
+    "ms": {
+      "browsers": {
+        "ie": "9 - *"
+      }
+    },
+    "o": {
+      "browsers": {
+        "opera": "11.5 - 12.1",
+        "op_mini": "*",
+        "op_mob": "*"
+      }
+    },
+    "webkit": {
+      "browsers": {
+        "android": "*",
+        "bb": "*",
+        "chrome": "1 - 33",
+        "ios_chr": "*",
+        "opera": "15",
+        "safari": "5 - *",
+        "ios_saf": "*"
+      }
+    }
+  }
 }

--- a/polyfills/Element/config.json
+++ b/polyfills/Element/config.json
@@ -1,23 +1,23 @@
 {
-	"aliases": [
-		"default"
-	],
-	"variants": {
-		"ie7": {
-			"browsers": {
-				"ie": "6 - 7"
-			},
-			"dependencies": [
-				"Document"
-			]
-		},
-		"ie8": {
-			"browsers": {
-				"ie": "8"
-			},
-			"dependencies": [
-				"Document"
-			]
-		}
-	}
+  "aliases": [
+    "default"
+  ],
+  "variants": {
+    "ie7": {
+      "browsers": {
+        "ie": "6 - 7"
+      },
+      "dependencies": [
+        "Document"
+      ]
+    },
+    "ie8": {
+      "browsers": {
+        "ie": "8"
+      },
+      "dependencies": [
+        "Document"
+      ]
+    }
+  }
 }

--- a/polyfills/Event.DOMContentLoaded/config.json
+++ b/polyfills/Event.DOMContentLoaded/config.json
@@ -1,11 +1,12 @@
 {
-	"aliases": [
-		"caniuse:domcontentloaded"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	},
-	"dependencies": [
-		"Event"
-	]
+  "aliases": [
+    "caniuse:domcontentloaded",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  },
+  "dependencies": [
+    "Event"
+  ]
 }

--- a/polyfills/Event.focusin/config.json
+++ b/polyfills/Event.focusin/config.json
@@ -1,8 +1,11 @@
 {
-	"browsers": {
-		"firefox": "3.6 - *"
-	},
-	"dependencies": [
-		"Event"
-	]
+  "browsers": {
+    "firefox": "3.6 - *"
+  },
+  "dependencies": [
+    "Event"
+  ],
+  "aliases": [
+    "default"
+  ]
 }

--- a/polyfills/Event.hashchange/config.json
+++ b/polyfills/Event.hashchange/config.json
@@ -1,13 +1,14 @@
 {
-	"aliases": [
-		"caniuse:hashchange",
-		"modernizr:hashchange"
-	],
-	"browsers": {
-		"ie": "6 - 7",
-		"safari": "4"
-	},
-	"dependencies": [
-		"Event"
-	]
+  "aliases": [
+    "caniuse:hashchange",
+    "modernizr:hashchange",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 7",
+    "safari": "4"
+  },
+  "dependencies": [
+    "Event"
+  ]
 }

--- a/polyfills/Event/config.json
+++ b/polyfills/Event/config.json
@@ -1,34 +1,34 @@
 {
-	"aliases": [
-		"default"
-	],
-	"browsers": {
-		"firefox": "6 - 10",
-		"ie": "9 - 10",
-		"opera": "10 - 11.5",
-		"safari": "4 - *"
-	},
-	"dependencies": [
-		"Window"
-	],
-	"variants": {
-		"ie8": {
-			"browsers": {
-				"ie": "6 - 8"
-			},
-			"dependencies": [
-				"Window",
-				"Document",
-				"Element"
-			]
-		},
-		"firefox5": {
-			"browsers": {
-				"firefox": "3.6 - 5"
-			},
-			"dependencies": [
-				"Window"
-			]
-		}
-	}
+  "aliases": [
+    "default"
+  ],
+  "browsers": {
+    "firefox": "6 - 10",
+    "ie": "9 - 10",
+    "opera": "10 - 11.5",
+    "safari": "4 - *"
+  },
+  "dependencies": [
+    "Window"
+  ],
+  "variants": {
+    "ie8": {
+      "browsers": {
+        "ie": "6 - 8"
+      },
+      "dependencies": [
+        "Window",
+        "Document",
+        "Element"
+      ]
+    },
+    "firefox5": {
+      "browsers": {
+        "firefox": "3.6 - 5"
+      },
+      "dependencies": [
+        "Window"
+      ]
+    }
+  }
 }

--- a/polyfills/Function.prototype.bind/config.json
+++ b/polyfills/Function.prototype.bind/config.json
@@ -1,12 +1,12 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5function"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"firefox": "3.6",
-		"safari": "4 - 5.1"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5function",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8",
+    "firefox": "3.6",
+    "safari": "4 - 5.1"
+  }
 }

--- a/polyfills/JSON/config.json
+++ b/polyfills/JSON/config.json
@@ -1,11 +1,11 @@
 {
-	"aliases": [
-		"default",
-		"caniuse:json",
-		"modernizr:json"
-	],
-	"browsers": {
-		"ie": "6 - 7"
-	},
-	"license": "MIT Asen Bozhilov JSON.parse (https://github.com/abozhilov/json)"
+  "aliases": [
+    "caniuse:json",
+    "modernizr:json",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 7"
+  },
+  "license": "MIT Asen Bozhilov JSON.parse (https://github.com/abozhilov/json)"
 }

--- a/polyfills/Object.assign/config.json
+++ b/polyfills/Object.assign/config.json
@@ -1,19 +1,20 @@
 {
-	"aliases": [
-		"es6",
-		"modernizr:es6object"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "1 - 33",
-		"ie": "*",
-		"ios_chr": "*",
-		"ios_saf": "*",
-		"opera": "*",
-		"op_mob": "*",
-		"op_mini": "*",
-		"safari": "*"
-	}
+  "aliases": [
+    "es6",
+    "modernizr:es6object",
+    "default"
+  ],
+  "browsers": {
+    "android": "*",
+    "bb": "*",
+    "chrome": "*",
+    "firefox": "1 - 33",
+    "ie": "*",
+    "ios_chr": "*",
+    "ios_saf": "*",
+    "opera": "*",
+    "op_mob": "*",
+    "op_mini": "*",
+    "safari": "*"
+  }
 }

--- a/polyfills/Object.create/config.json
+++ b/polyfills/Object.create/config.json
@@ -1,14 +1,15 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"firefox": "3.6",
-		"safari": "4"
-	},
-	"dependencies": [
-		"Object.defineProperties"
-	]
+  "aliases": [
+    "es5",
+    "modernizr:es5object",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8",
+    "firefox": "3.6",
+    "safari": "4"
+  },
+  "dependencies": [
+    "Object.defineProperties"
+  ]
 }

--- a/polyfills/Object.defineProperties/config.json
+++ b/polyfills/Object.defineProperties/config.json
@@ -1,13 +1,14 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"safari": "4 - 4.1"
-	},
-	"dependencies": [
-		"Object.defineProperty"
-	]
+  "aliases": [
+    "es5",
+    "modernizr:es5object",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8",
+    "safari": "4 - 4.1"
+  },
+  "dependencies": [
+    "Object.defineProperty"
+  ]
 }

--- a/polyfills/Object.defineProperty/config.json
+++ b/polyfills/Object.defineProperty/config.json
@@ -1,23 +1,24 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object"
-	],
-	"browsers": {
-		"firefox": "3.6",
-		"safari": "4 - 4.1",
-		"ios_saf": "4.3"
-	},
-	"variants": {
-		"ie7": {
-			"browsers": {
-				"ie": "6 - 7"
-			}
-		},
-		"ie8": {
-			"browsers": {
-				"ie": "8"
-			}
-		}
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5object",
+    "default"
+  ],
+  "browsers": {
+    "firefox": "3.6",
+    "safari": "4 - 4.1",
+    "ios_saf": "4.3"
+  },
+  "variants": {
+    "ie7": {
+      "browsers": {
+        "ie": "6 - 7"
+      }
+    },
+    "ie8": {
+      "browsers": {
+        "ie": "8"
+      }
+    }
+  }
 }

--- a/polyfills/Object.getOwnPropertyNames/config.json
+++ b/polyfills/Object.getOwnPropertyNames/config.json
@@ -1,17 +1,18 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object"
-	],
-	"browsers": {
-		"firefox": "3.6",
-		"safari": "4"
-	},
-	"variants": {
-		"ie8": {
-			"browsers": {
-				"ie": "6 - 8"
-			}
-		}
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5object",
+    "default"
+  ],
+  "browsers": {
+    "firefox": "3.6",
+    "safari": "4"
+  },
+  "variants": {
+    "ie8": {
+      "browsers": {
+        "ie": "6 - 8"
+      }
+    }
+  }
 }

--- a/polyfills/Object.getPrototypeOf/config.json
+++ b/polyfills/Object.getPrototypeOf/config.json
@@ -1,11 +1,12 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"firefox": "3.6",
-		"safari": "4"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5object",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8",
+    "firefox": "3.6",
+    "safari": "4"
+  }
 }

--- a/polyfills/Object.keys/config.json
+++ b/polyfills/Object.keys/config.json
@@ -1,11 +1,12 @@
 {
-	"aliases": [
-		"es5",
-		"modernizr:es5object"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"firefox": "3.6",
-		"safari": "4"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5object",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8",
+    "firefox": "3.6",
+    "safari": "4"
+  }
 }

--- a/polyfills/String.prototype.contains/config.json
+++ b/polyfills/String.prototype.contains/config.json
@@ -1,17 +1,17 @@
 {
-	"aliases": [
-		"default",
-		"es6",
-		"modernizr:es6string"
-	],
-	"browsers": {
-		"android": "*",
-		"bb": "*",
-		"chrome": "*",
-		"firefox": "3.6 - 17",
-		"opera": "10 - 18",
-		"safari": "*",
-		"ie": "6 - *",
-		"ios_saf": "*"
-	}
+  "aliases": [
+    "es6",
+    "modernizr:es6string",
+    "default"
+  ],
+  "browsers": {
+    "android": "*",
+    "bb": "*",
+    "chrome": "*",
+    "firefox": "3.6 - 17",
+    "opera": "10 - 18",
+    "safari": "*",
+    "ie": "6 - *",
+    "ios_saf": "*"
+  }
 }

--- a/polyfills/String.prototype.trim/config.json
+++ b/polyfills/String.prototype.trim/config.json
@@ -1,11 +1,11 @@
 {
-	"aliases": [
-		"default",
-		"es5",
-		"modernizr:es5string"
-	],
-	"browsers": {
-		"ie": "6 - 8",
-		"safari": "4"
-	}
+  "aliases": [
+    "es5",
+    "modernizr:es5string",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8",
+    "safari": "4"
+  }
 }

--- a/polyfills/Window/config.json
+++ b/polyfills/Window/config.json
@@ -1,18 +1,18 @@
 {
-	"aliases": [
-		"default"
-	],
-	"browsers": {
-		"ie": "6 - 7",
-		"opera": "10 - 11.6",
-		"safari": "4 - 5"
-	},
-	"variants": {
-		"chrome": {
-			"browsers": {
-				"chrome": "14 - 18",
-				"safari": "5.1"
-			}
-		}
-	}
+  "aliases": [
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 7",
+    "opera": "10 - 11.6",
+    "safari": "4 - 5"
+  },
+  "variants": {
+    "chrome": {
+      "browsers": {
+        "chrome": "14 - 18",
+        "safari": "5.1"
+      }
+    }
+  }
 }

--- a/polyfills/XMLHttpRequest/config.json
+++ b/polyfills/XMLHttpRequest/config.json
@@ -1,11 +1,11 @@
 {
-	"aliases": [
-		"default"
-	],
-	"browsers": {
-		"ie": "6 - 8"
-	},
-	"dependencies": [
-		"Event"
-	]
+  "aliases": [
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 8"
+  },
+  "dependencies": [
+    "Event"
+  ]
 }

--- a/polyfills/base64/config.json
+++ b/polyfills/base64/config.json
@@ -1,11 +1,11 @@
 {
-	"aliases": [
-		"default",
-		"caniuse:datauri"
-	],
-	"browsers": {
-		"ie": "6 - 9"
-	},
-	"license": "MIT",
-	"author": "David Lindquist (http://www.webtoolkit.info/javascript-base64.html), Andrew Dodson (drew81.com)"
+  "aliases": [
+    "caniuse:datauri",
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 9"
+  },
+  "license": "MIT",
+  "author": "David Lindquist (http://www.webtoolkit.info/javascript-base64.html), Andrew Dodson (drew81.com)"
 }

--- a/polyfills/document.querySelector/config.json
+++ b/polyfills/document.querySelector/config.json
@@ -1,11 +1,11 @@
 {
-	"aliases": [
-		"default"
-	],
-	"browsers": {
-		"ie": "6 - 7"
-	},
-	"dependencies": [
-		"Element"
-	]
+  "aliases": [
+    "default"
+  ],
+  "browsers": {
+    "ie": "6 - 7"
+  },
+  "dependencies": [
+    "Element"
+  ]
 }

--- a/polyfills/requestAnimationFrame/config.json
+++ b/polyfills/requestAnimationFrame/config.json
@@ -1,32 +1,32 @@
 {
-	"aliases": [
-		"default",
-		"caniuse:requestanimationframe",
-		"modernizr:requestanimationframe"
-	],
-	"browsers": {
-		"bb": "7",
-		"chrome": "1 - 9",
-		"ie": "6 - 9",
-		"ios_saf": "3.2 - 5.1",
-		"firefox": "3.6",
-		"opera": "9 - 12.1",
-		"op_mini": "5 - 7",
-		"op_mob": "10 - 12.1",
-		"safari": "3.1 - 5.1"
-	},
-	"variants": {
-		"moz": {
-			"browsers": {
-				"firefox": "4 - 22"
-			}
-		},
-		"webkit": {
-			"browsers": {
-				"chrome": "10 - 23",
-				"safari": "6"
-			}
-		}
-	},
-	"license": "requestAnimationFrame polyfill by Erik Möller, fixes from Paul Irish, Tino Zijdel, and Jonathan Neal"
+  "aliases": [
+    "caniuse:requestanimationframe",
+    "modernizr:requestanimationframe",
+    "default"
+  ],
+  "browsers": {
+    "bb": "7",
+    "chrome": "1 - 9",
+    "ie": "6 - 9",
+    "ios_saf": "3.2 - 5.1",
+    "firefox": "3.6",
+    "opera": "9 - 12.1",
+    "op_mini": "5 - 7",
+    "op_mob": "10 - 12.1",
+    "safari": "3.1 - 5.1"
+  },
+  "variants": {
+    "moz": {
+      "browsers": {
+        "firefox": "4 - 22"
+      }
+    },
+    "webkit": {
+      "browsers": {
+        "chrome": "10 - 23",
+        "safari": "6"
+      }
+    }
+  },
+  "license": "requestAnimationFrame polyfill by Erik Möller, fixes from Paul Irish, Tino Zijdel, and Jonathan Neal"
 }

--- a/utils/polyfillSuggestor.js
+++ b/utils/polyfillSuggestor.js
@@ -1,0 +1,26 @@
+var testReport = require('./polyfillTestReport')();
+var polyfillsBySize = require('./polyfillsBySize')();
+
+var polyfillsUnder1k = polyfillsBySize.filter(function(polyfill){
+	return polyfill.size < 1;
+});
+
+function hasTest(polyfill){
+	for(var i= 0, l=testReport.hasTests.length; i<l; i++){
+		if(testReport.hasTests[i].name === polyfill.name.trim()){
+			return true;
+		}
+	}
+
+	return false;
+}
+
+var suggestedPolyfills = polyfillsUnder1k.filter(hasTest);
+
+console.log('The following Polyfills are < 1k and have tests:');
+console.log('   ');
+suggestedPolyfills.forEach(function(p){
+	console.log(p.name);
+});
+
+

--- a/utils/polyfillTestReport.js
+++ b/utils/polyfillTestReport.js
@@ -1,0 +1,83 @@
+var fs = require('fs');
+var path = require('path');
+var UglifyJS = require('uglify-js');
+
+//
+
+function getAllPolyfills(polyfillRootPath){
+	try{
+		var files = fs.readdirSync(polyfillRootPath);
+		var polyfills = [];
+
+		files.forEach(function(file){
+			var testPath = path.resolve(polyfillRootPath, file + '/tests.js');
+			var fullPath = path.resolve(polyfillRootPath, file + '/polyfill.js');
+			if(fs.existsSync(fullPath)){
+				polyfills.push({name: file, hasTests : fs.existsSync(testPath)});
+			}
+		});
+
+		return polyfills;
+	}catch(e){
+		fail(e);
+	}
+}
+
+
+function sort(polyfills){
+	var hasTests = [], noTests = [];
+	polyfills.forEach(function(polyfill){
+		if(polyfill.hasTests){
+			hasTests.push(polyfill);
+		}else{
+			noTests.push(polyfill);
+		}
+	});
+
+	return { hasTests : hasTests, noTests : noTests};
+}
+
+function output(polyfills){
+	console.log('POLYFILLS WITH TESTS (' + polyfills.hasTests.length + ')');
+	console.log('=====================');
+	polyfills.hasTests.forEach(function(polyfill){
+		console.log(polyfill.name);
+	});
+	console.log('                     ');
+	console.log('POLYFILLS WITHOUT TESTS (' + polyfills.noTests.length + ')');
+	console.log('=====================');
+	polyfills.noTests.forEach(function(polyfill){
+		console.log(polyfill.name);
+	});
+}
+
+function writeToFile(polyFills, file){
+	fs.writeFileSync(file, JSON.stringify(polyFills, null, 2), {encoding:'utf8'});
+}
+
+function fail(err){
+	throw err;
+}
+
+
+function main(silent){
+	if(typeof silent === 'undefined'){
+		silent = true;
+	}
+
+	var polyfillRootPath = path.resolve(__dirname, '../', 'polyfills/');
+	var polyfills = getAllPolyfills(polyfillRootPath);
+	polyfills = sort(polyfills);
+	if(!silent){
+		output(polyfills);
+		writeToFile(polyfills, 'polyfillTestReport.json');
+	}else{
+		return polyfills;
+	}
+}
+
+if(require.main === module) {
+	main(false);
+} else {
+	module.exports = main;
+}

--- a/utils/polyfillsBySize.js
+++ b/utils/polyfillsBySize.js
@@ -1,0 +1,102 @@
+var fs = require('fs');
+var path = require('path');
+var UglifyJS = require('uglify-js');
+
+//
+
+function getAllPolyfills(polyfillRootPath){
+	try{
+		var files = fs.readdirSync(polyfillRootPath);
+		var polyfills = [];
+
+		files.forEach(function(file){
+			var folderPath = path.resolve(polyfillRootPath, file);
+			var fullPaths = fs.readdirSync(folderPath).filter(function(p){
+				return (p.indexOf('polyfill') > -1);
+			});
+
+			fullPaths.forEach(function(p){
+				var subname = p.indexOf('-') > -1 ? '(' + p.split('-')[1].replace('.js', '') + ')' : '';
+				if(subname === '' && fullPaths.length > 1){
+					subname = '(default)'
+				}
+				var name = file + ' ' + subname;
+				polyfills.push({name:name, src: fs.readFileSync(folderPath + '/' + p, {encoding:'utf8'})});
+			});
+		});
+
+		return polyfills;
+	}catch(e){
+		fail(e);
+	}
+}
+
+function minifyPolyfills(polyfills){
+	polyfills.forEach(function(polyfill){
+		polyfill.minified = UglifyJS.minify(polyfill.src, {fromString: true});
+		delete polyfill.src;
+	});
+
+	return polyfills;
+}
+
+function calculateSizes(polyfills){
+	polyfills.forEach(function(polyfill){
+		polyfill.size = (Buffer.byteLength(polyfill.minified.code, 'utf8') / 1024).toFixed(2);
+		delete polyfill.minified;
+	});
+
+	return polyfills;
+}
+
+function sort(polyfills){
+	return polyfills.sort(function(a, b){
+		return b.size - a.size;
+	});
+}
+
+function output(polyfills){
+	var over1k = true;
+	polyfills.forEach(function(polyfill, i){
+		if(over1k && polyfill.size < 1 && i > 0){
+			console.log('**************************');
+			over1k = false;
+		}
+		if(polyfill.size > 0){
+			console.log(polyfill.name + '     ' + polyfill.size + 'K');
+		}
+	});
+}
+
+function writeToFile(polyFills, file){
+	fs.writeFileSync(file, JSON.stringify(polyFills, null, 2), {encoding:'utf8'});
+}
+
+function fail(err){
+	throw err;
+}
+
+
+function main(silent){
+	if(typeof silent === 'undefined'){
+		silent = true;
+	}
+
+	var polyfillRootPath = path.resolve(__dirname, '../', 'polyfills/');
+	var polyfills = getAllPolyfills(polyfillRootPath);
+	polyfills = minifyPolyfills(polyfills);
+	polyfills = calculateSizes(polyfills);
+	polyfills = sort(polyfills);
+	if(!silent){
+		output(polyfills);
+		writeToFile(polyfills, 'polyfillsizes.json');
+	}else{
+		return polyfills;
+	}
+}
+
+if(require.main === module) {
+	main(false);
+} else {
+	module.exports = main;
+}


### PR DESCRIPTION
As discussed, in [https://github.com/Financial-Times/polyfill-service/issues/176](issue#176) I have added the following polyfills to the default set:
- Event.DOMContentLoaded
- Event.focusin
- Event.hashchange
- Object.assign
- Object.create
- Object.defineProperties
- Object.defineProperty
- Object.getOwnPropertyNames
- Object.getPrototypeOf
- Object.keys
