### PR TITLE
fixing detect script to work in safari 5

### DIFF
--- a/polyfills/Event/detect.js
+++ b/polyfills/Event/detect.js
@@ -1,3 +1,14 @@
-'Event' in window &&
-(typeof window.Event === 'function' ||
-(window.Event.toString().indexOf('EventConstructor')>-1))
+(function(){
+	if(!'Event' in window) return false;
+
+	if(typeof window.Event === 'function') return true;
+
+	var result = true;
+	try{
+		new Event('click');
+	}catch(e){
+		result = false;
+	}
+
+	return result;
+}())

--- a/polyfills/Event/detect.js
+++ b/polyfills/Event/detect.js
@@ -3,12 +3,10 @@
 
 	if(typeof window.Event === 'function') return true;
 
-	var result = true;
 	try{
 		new Event('click');
+		return true;
 	}catch(e){
-		result = false;
+		return false;
 	}
-
-	return result;
-}())
+}());


### PR DESCRIPTION
Detecting support for the Event constructor is quite tricky, it turns out.

In safari 5 -7 window.Event is '[object EventConstructor]' but cannot be instantiated with the new keyword as it not actually an constructor(!)  In safari 8 it can be instantiated but is still instanceof Object, not Function(!!).  In new versions of IE it also an object but cannot be intantiated.

Therefore try/catch is only safe way to detect whether or not this works...
