### PR TITLE
Fix library usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "polyfill-service",
   "description": "A polyfill combinator",
+  "main": "lib/index.js",
   "contributors": [
     {
       "name": "Jonathan Neal",


### PR DESCRIPTION
Library examples from README does not work currently. There is no
"main" entry or "index.js" file in the root of the repo. Fixed by
adding "main: lib/index.js" to package.json
