### PR TITLE
Fixed erroneous parameters for Math.imul polyfill.

### DIFF
--- a/polyfills/Math.imul/polyfill.js
+++ b/polyfills/Math.imul/polyfill.js
@@ -1,4 +1,4 @@
-Math.imul = function imul(x) {
+Math.imul = function imul(a, b) {
 	var
 	ah  = (a >>> 16) & 0xffff,
 	al = a & 0xffff,


### PR DESCRIPTION
Fixed an error in this polyfill for Math.imul. The original expected parameters a and b to be the operators for imul, but had only the parameter x declared.
