### PR TITLE
Object.assign on Internet Explorer Mobile

### DIFF
--- a/polyfills/Object.assign/config.json
+++ b/polyfills/Object.assign/config.json
@@ -10,6 +10,7 @@
 		"chrome": "*",
 		"firefox": "1 - 33",
 		"ie": "*",
+		"ie_mob": "*",
 		"ios_chr": "*",
 		"ios_saf": "*",
 		"opera": "*",


### PR DESCRIPTION
Object.assign needs to be loaded on Internet Explorer Mobile
